### PR TITLE
add nice VarDump suppor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 php:
     - '5.5'
+    - '5.6'
+    - '5.7'
     - '7.0'
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 php:
     - '5.5'
     - '5.6'
-    - '5.7'
     - '7.0'
 
 services:

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -383,6 +383,26 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         return $d.' <span style="color:gray">[' . implode(', ', $pp) . ']</span>';
     }
 
+    function __debugInfo()
+    {
+
+        $arr = [
+            'R'=>false,
+            'template'=>$this->template,
+            'params'=>$this->params,
+            'connection'=>$this->connection,
+            'args'=>$this->args,
+        ];
+
+        try {
+            $arr['R'] = $this->render();
+        } catch (Exception $e) {
+            $arr['R'] = $e->getMessage();
+        }
+
+        return $arr;
+    }
+
     /**
      * Execute expression
      *

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -396,7 +396,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
 
         try {
             $arr['R'] = $this->render();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $arr['R'] = $e->getMessage();
         }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -1076,7 +1076,7 @@ class Query extends Expression
 
         try {
             $arr['R'] = $this->render();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $arr['R'] = $this->getMessage();
         }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -1061,6 +1061,27 @@ class Query extends Expression
     }
     // }}}
 
+    function __debugInfo()
+    {
+        $arr =  [
+            'R'=>false,
+            'mode'=>$this->mode,
+            'template'=>$this->template,
+            'params'=>$this->params,
+            'connection'=>$this->connection,
+            'main_table'=>$this->main_table,
+            'args'=>$this->args,
+        ];
+
+        try {
+            $arr['R'] = $this->render();
+        } catch (Exception $e) {
+            $arr['R'] = $this->getMessage();
+        }
+
+        return $arr;
+    }
+
     // {{{ Miscelanious
     /**
      * Renders query template. If the template is not explicitly set will use "select" mode.

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -415,19 +415,19 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 
     public function testVarDump()
     {
-        $this->expectOutputRegex('/select \* from `user`/');
+        $this->expectOutputRegex('/.*select \* from `user`.*/');
         var_dump($this->q()->table('user'));
     }
 
     public function testVarDump2()
     {
-        $this->expectOutputRegex('/Expression could not render tag/');
+        $this->expectOutputRegex('/.*Expression could not render tag.*/');
         var_dump(new Expression('Hello [world]'));
     }
 
     public function testVarDump3()
     {
-        $this->expectOutputRegex('/Hello :a/');
+        $this->expectOutputRegex('/.*Hello :a.*/');
         var_dump(new Expression('Hello [world]',['world'=>'php']));
     }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -436,7 +436,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
      */
     public function testVarDump3()
     {
-        $this->expectOutputRegex('/.*Heillo :a.*/');
+        $this->expectOutputRegex('/.*Hello :a.*/');
         var_dump(new Expression('Hello [world]',['world'=>'php']));
     }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -413,7 +413,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /*
+    /**
      * @requires PHP 5.6
      */
     public function testVarDump()
@@ -422,7 +422,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         var_dump($this->q()->table('user'));
     }
 
-    /*
+    /**
      * @requires PHP 5.6
      */
     public function testVarDump2()
@@ -431,12 +431,12 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         var_dump(new Expression('Hello [world]'));
     }
 
-    /*
+    /**
      * @requires PHP 5.6
      */
     public function testVarDump3()
     {
-        $this->expectOutputRegex('/.*Hello :a.*/');
+        $this->expectOutputRegex('/.*Heillo :a.*/');
         var_dump(new Expression('Hello [world]',['world'=>'php']));
     }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -414,6 +414,24 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testVarDump()
+    {
+        $this->expectOutputRegex('/select \* from `user`/');
+        var_dump($this->q()->table('user'));
+    }
+
+    public function testVarDump2()
+    {
+        $this->expectOutputRegex('/Expression could not render tag/');
+        var_dump(new Expression('Hello [world]'));
+    }
+
+    public function testVarDump3()
+    {
+        $this->expectOutputRegex('/Hello :a/');
+        var_dump(new Expression('Hello [world]',['world'=>'php']));
+    }
+
     /**
      * @covers ::field
      * @covers ::_render_field

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -413,18 +413,27 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /*
+     * @requires PHP 5.6
+     */
     public function testVarDump()
     {
         $this->expectOutputRegex('/.*select \* from `user`.*/');
         var_dump($this->q()->table('user'));
     }
 
+    /*
+     * @requires PHP 5.6
+     */
     public function testVarDump2()
     {
         $this->expectOutputRegex('/.*Expression could not render tag.*/');
         var_dump(new Expression('Hello [world]'));
     }
 
+    /*
+     * @requires PHP 5.6
+     */
     public function testVarDump3()
     {
         $this->expectOutputRegex('/.*Hello :a.*/');


### PR DESCRIPTION
Previously var_dump($query) would output a lot of garbage:

```
class atk4\dsql\Query#382 (11) {
  public $templates =>
  array(6) {
    'select' =>
    string(64) "select [field] [from] [table][join][where][having][order][limit]"
    'delete' =>
    string(36) "delete [from] [table][where][having]"
    'insert' =>
    string(64) "insert into [table_noalias] ([set_fields]) values ([set_values])"
    'replace' =>
    string(65) "replace into [table_noalias] ([set_fields]) values ([set_values])"
    'update' =>
    string(40) "update [table_noalias] set [set] [where]"
    'truncate' =>
    string(30) "truncate table [table_noalias]"
  }
  public $mode =>
  string(6) "select"
  public $defaultField =>
  string(1) "*"
  protected $main_table =>
  string(4) "user"
  protected $template =>
  NULL
..
```

Now this is cleaned up like this:
```
class atk4\dsql\Query#386 (7) {
  public $R =>
  string(20) "select * from `user`"
  public $mode =>
  string(6) "select"
  public $template =>
  NULL
  public $params =>
  array(0) {
  }
  public $connection =>
  NULL
  public $main_table =>
  string(4) "user"
  public $args =>
  array(2) {
    'custom' =>
    array(0) {
    }
    'table' =>
    array(1) {
      [0] =>
      array(2) {
        ...
      }
    }
  }
}
```

for expressions it's also cleaner:

```
class atk4\dsql\Expression#388 (5) {
  public $R =>
  string(31) "Expression could not render tag"
  public $template =>
  string(13) "Hello [world]"
  public $params =>
  array(0) {
  }
  public $connection =>
  NULL
  public $args =>
  array(1) {
    'custom' =>
    array(0) {
    }
  }
}
```