### PR TITLE
Feature/refactor table

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -231,7 +231,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
             throw new Exception(['Only Expressions or Expressionable objects may be used in Expression','object'=>$sql_code]);
         }
 
-         //|| !$sql_code instanceof Expression) {
+        // at this point $sql_code is instance of Expression
         $sql_code->params = &$this->params;
         $sql_code->_paramBase = &$this->_paramBase;
         $ret = $sql_code->render();
@@ -383,7 +383,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         return $d.' <span style="color:gray">[' . implode(', ', $pp) . ']</span>';
     }
 
-    function __debugInfo()
+    public function __debugInfo()
     {
 
         $arr = [

--- a/src/Query.php
+++ b/src/Query.php
@@ -40,7 +40,7 @@ class Query extends Expression
     public $defaultField = '*';
 
     /**
-     * Name of base table to use when using default join().
+     * Name or alias of base table to use when using default join().
      *
      * This is set by table(). If you are using multiple tables,
      * then $main_table is set to false as it is irrelevant.
@@ -227,51 +227,6 @@ class Query extends Expression
        // if all is fine, then save table in args
         $this->args['table'][$alias] = $table;
 
-
-
-        // table can be expression, but then we can only set the table once
-        // @todo WHY such restriction ?
-        /*
-        if ($table instanceof Expression) {
-
-            if (isset($this->args['table'])) {
-                throw new Exception('You cannot use table(expression). table() was called before');
-            }
-
-            $this->main_table = false;
-            // @todo Imants: Only saves table (expression) and doesn't save table/expression alias!?!
-            $this->args['table'] = $table;
-
-            return $this;
-        }
-
-        // initialize args[table] array
-        if (!isset($this->args['table'])) {
-            $this->args['table'] = array();
-        }
-
-        // @todo WHY such restriction ?
-        if ($this->args['table'] instanceof Expression) {
-            throw new Exception('You cannot use table(). You have already used table(expression) previously.');
-        }
-
-        // trim table name just in case developer called it like 'employees,    jobs'
-        $table = trim($table);
-
-        // main_table will be set only if table() is called once. It's used
-        // when joining with other tables
-        if ($this->main_table === null) {
-            $this->main_table = $alias ?: $table;
-
-            // on multiple calls, main_table will be false and we won't
-            // be able to join easily anymore.
-        } elseif ($this->main_table) {
-            $this->main_table = false;   // query from multiple tables
-        }
-
-        $this->args['table'][] = array($table, $alias);
-        */
-
         return $this;
     }
 
@@ -316,35 +271,6 @@ class Query extends Expression
             $ret[] = $table;
         }
 
-
-
-        /*
-        // will be joined for output
-        $ret = [];
-
-        if (empty($this->args['table'])) {
-            return '';
-        }
-
-        if ($this->args['table'] instanceof Expression) {
-
-            // This will wrap into () if Query object is used here
-            return $this->_consume($this->args['table']);
-        }
-
-        foreach ($this->args['table'] as $row) {
-            list($table, $alias) = $row;
-
-            $table = $this->_escape($table);
-
-            if ($alias !== null) {
-                $table .= ' ' . $this->_escape($alias);
-            }
-
-            $ret[] = $table;
-        }
-        */
-
         return implode(',', $ret);
     }
 
@@ -357,25 +283,6 @@ class Query extends Expression
     protected function _render_table_noalias()
     {
         return $this->_render_table(false);
-
-        /*
-        // will be joined for output
-        $ret = [];
-
-        if ($this->args['table'] instanceof Expression) {
-            throw new Exception('Table cannot be expression for UPDATE / INSERT queries in '.__METHOD__);
-        }
-
-        foreach ($this->args['table'] as $row) {
-            list($table, ) = $row;
-
-            $table = $this->_escape($table);
-
-            $ret[] = $table;
-        }
-
-        return implode(', ', $ret);
-        */
     }
 
     /**

--- a/src/Query.php
+++ b/src/Query.php
@@ -306,12 +306,7 @@ class Query extends Expression
      */
     protected function _render_from()
     {
-        return isset($this->main_table) ? 'from' : '';
-        /**
-         * @todo Imants: maybe we can change this to
-         *  return !empty($this->args['table']) ? 'from' : ''
-         * and get rid of main_table.
-         */
+        return empty($this->args['table']) ? '' : 'from';
     }
     /// }}}
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -123,7 +123,7 @@ class Query extends Expression
         $ret = [];
 
         // If no fields were defined, use defaultField
-        if (!isset($this->args['fields']) || empty($this->args['fields'])) {
+        if (empty($this->args['fields'])) {
             if ($this->defaultField instanceof Expression) {
                 return $this->_consume($this->defaultField);
             }
@@ -298,11 +298,16 @@ class Query extends Expression
                 throw new Exception('Table cannot be expression for UPDATE, INSERT etc. queries');
             }
 
+            // add alias only if it's not the same as table name
+            if ($add_alias === false || (is_string($table) && $alias === $table)) {
+                $alias = '';
+            }
+
             // consume or escape table
             $table = $this->_consume($table, 'escape');
 
             // add alias if it's not the same as table name
-            if ($add_alias && $alias != $table) {
+            if ($alias) {
                 $table .= ' ' . $this->_escape($alias);
             }
 
@@ -385,7 +390,7 @@ class Query extends Expression
 
     // {{{ join()
     /**
-     * Joins your query with another table. Join will use $main_table in
+     * Joins your query with another table. Join will use $main_table
      * to reference the main table, unless you specify it explicitly
      *
      * Examples:

--- a/src/Query.php
+++ b/src/Query.php
@@ -172,7 +172,7 @@ class Query extends Expression
     {
         // comma-separated table names
         if (is_string($table) && strpos($table, ',') !== false) {
-            $table = explode(',', $table);
+            $table = array_map('trim', explode(',', $table));
         }
 
         // array of tables - recursively process each
@@ -201,9 +201,6 @@ class Query extends Expression
         if (!isset($this->args['table'])) {
             $this->args['table'] = array();
         }
-
-        // trim table name just in case developer called it like 'employees,    jobs'
-        $table = trim($table);
 
         // if no alias is set, then we will use table name as alias
         // in such case alias will not render, but will be used as array key
@@ -306,7 +303,7 @@ class Query extends Expression
             // consume or escape table
             $table = $this->_consume($table, 'escape');
 
-            // add alias if it's not the same as table name
+            // add alias if needed
             if ($alias) {
                 $table .= ' ' . $this->_escape($alias);
             }

--- a/src/Query.php
+++ b/src/Query.php
@@ -172,7 +172,7 @@ class Query extends Expression
     {
         // comma-separated table names
         if (is_string($table) && strpos($table, ',') !== false) {
-            $table = array_map('trim', explode(',', $table));
+            $table = explode(',', $table);
         }
 
         // array of tables - recursively process each
@@ -192,14 +192,14 @@ class Query extends Expression
             return $this;
         }
 
-        // if table is set as Expression, then alias is mandatory
-        if ($table instanceof Expression && $alias === null) {
+        // if table is set as object, then alias is mandatory
+        if (is_object($table) && $alias === null) {
             throw new Exception('If table is set as Expression, then table alias is mandatory');
         }
 
-        // initialize args[table] array
-        if (!isset($this->args['table'])) {
-            $this->args['table'] = array();
+        // trim table name just in case developer called it like 'employees,    jobs'
+        if (is_string($table)) {
+            $table = trim($table);
         }
 
         // if no alias is set, then we will use table name as alias
@@ -218,6 +218,11 @@ class Query extends Expression
         // on multiple calls, main_table will be false and we won't
         // be able to join easily anymore.
         $this->main_table = ($this->main_table === null ? $alias : false);
+
+        // initialize args[table] array
+        if (!isset($this->args['table'])) {
+            $this->args['table'] = array();
+        }
 
        // if all is fine, then save table in args
         $this->args['table'][$alias] = $table;

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -422,6 +422,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
                 ->field('name', 'c')
                 ->table($q1, 'e')
                 ->table($q2, 'c')
+                ->where('e.last_name', 'c.last_name')
                 ->render()
         );
     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -416,7 +416,8 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $q2 = $this->q()->table('customer');
 
         $this->assertEquals(
-            'select `e`.`name`,`c`.`name` from (select * from `employee`) `e`,(select * from `customer`) `c`',
+            //this way it would be more correct: 'select `e`.`name`,`c`.`name` from (select * from `employee`) `e`,(select * from `customer`) `c` where `e`.`last_name` = `c`.`last_name`',
+            'select `e`.`name`,`c`.`name` from (select * from `employee`) `e`,(select * from `customer`) `c` where `e`.`last_name` = c.last_name',
             $this->q()
                 ->field('name', 'e')
                 ->field('name', 'c')

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -222,6 +222,71 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Table aliases should be unique
+     *
+     * @covers ::table
+     * @expectedException Exception
+     */
+    public function testTableException5()
+    {
+        $this->q()
+            ->table('foo', 'a')
+            ->table('bar', 'a');
+    }
+
+    /**
+     * Table aliases should be unique
+     *
+     * @covers ::table
+     * @expectedException Exception
+     */
+    public function testTableException6()
+    {
+        $this->q()
+            ->table('foo', 'bar')
+            ->table('bar');
+    }
+
+    /**
+     * Table aliases should be unique
+     *
+     * @covers ::table
+     * @expectedException Exception
+     */
+    public function testTableException7()
+    {
+        $this->q()
+            ->table('foo')
+            ->table('foo');
+    }
+
+    /**
+     * Table aliases should be unique
+     *
+     * @covers ::table
+     * @expectedException Exception
+     */
+    public function testTableException8()
+    {
+        $this->q()
+            ->table($this->q()->table('test'), 'foo')
+            ->table('foo');
+    }
+
+    /**
+     * Table aliases should be unique
+     *
+     * @covers ::table
+     * @expectedException Exception
+     */
+    public function testTableException9()
+    {
+        $this->q()
+            ->table('foo')
+            ->table($this->q()->table('test'), 'foo');
+    }
+
+    /**
      * can't use table with expression
      *
      * @covers ::table
@@ -383,20 +448,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
          *  (select * from `customer`) `c`
          * In such case table alias should better be mandatory.
          */
-
-        /**
-         * @todo Add some tests with non-unique table aliases.
-         *  They will currently generate: SELECT * FROM `foo` `a`, `bar` `a` which is wrong!
-         * We have to check uniquness of table aliases and in such cases throw appropriate exception.
-         */
-        $q = $this->q()
-            ->table('foo', 'a')
-            ->table('bar', 'a');
-        $this->assertEquals(
-            'select * from `foo` `a`,`bar` `a`', // <-- aliases should be unique and THIS SHOULD THROW EXCEPTION
-            $q->render()
-        );
-
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -287,34 +287,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * can't use table with expression
-     *
-     * @covers ::table
-     * @expectedException Exception
-     */
-    public function testTableExprException1()
-    {
-        $q = $this->q();
-        $q
-            ->table($q->expr('test'))
-            ->table('user');
-    }
-
-    /**
-     * can't use table with expression
-     *
-     * @covers ::table
-     * @expectedException Exception
-     */
-    public function testTableExprException2()
-    {
-        $q = $this->q();
-        $q
-            ->table('user')
-            ->table($q->expr('test'));
-    }
-
-    /**
      * table() should return $this Query for chaining
      *
      * @covers ::table
@@ -439,15 +411,19 @@ class QueryTest extends \PHPUnit_Framework_TestCase
                 ->render()
         );
 
-        /**
-         * @todo Add more tests with multiple tables & subqueries
-         * Currently that's restricted, but I believe it should be allowed to create query like this
-         * SELECT `e`.`name`, `c`.`name`
-         * FROM
-         *  (select * from `employee`) `e`,
-         *  (select * from `customer`) `c`
-         * In such case table alias should better be mandatory.
-         */
+        // test with multiple sub-queries as tables
+        $q1 = $this->q()->table('employee');
+        $q2 = $this->q()->table('customer');
+
+        $this->assertEquals(
+            'select `e`.`name`,`c`.`name` from (select * from `employee`) `e`,(select * from `customer`) `c`',
+            $this->q()
+                ->field('name', 'e')
+                ->field('name', 'c')
+                ->table($q1, 'e')
+                ->table($q2, 'c')
+                ->render()
+        );
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -211,14 +211,14 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Alias is mandatory when pass table as Query
+     * Alias is mandatory when pass table as any object
      *
      * @covers ::table
      * @expectedException Exception
      */
     public function testTableException4()
     {
-        $this->q()->table($this->q()->table('test'));
+        $this->q()->table(new \stdClass());
     }
 
     /**
@@ -368,7 +368,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $q = $this->q()->table('employee');
 
         $this->assertEquals(
-            'select `e`.`name` from (select * from `employee`) `e`',
+            'select `name` from (select * from `employee`) `e`',
             $this->q()
                 ->field('name')->table($q, 'e')
                 ->render()

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -422,7 +422,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
                 ->field('name', 'c')
                 ->table($q1, 'e')
                 ->table($q2, 'c')
-                ->where('e.last_name', 'c.last_name')
+                ->where('e.last_name', $this->q()->expr('c.last_name'))
                 ->render()
         );
     }


### PR DESCRIPTION
* now you can add as many sub-queries as tables as you want to you query
* alias is mandatory if you set table as object (expression, query or whatever)
* main_table functionality almost not changed only little bit tweaked
* few psr fixes
* more tests