### PR TITLE
add support for {tag} in expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: php
+
+sudo: required
+
 php:
     - '5.5'
     - '5.6'
@@ -24,4 +27,3 @@ notifications:
             - agiletoolkit:bjrKuPBf1h4cYiNxPBQ1kF6c#dsql
         on_success: change
     email: false
-

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
  - `consume()` renamed into `_consume()`
  - `render_*` methods renamed into `_render_*`
  - `bt()` renamed into `_escape()`
- - `$bt` property renamed to `$escapeChar`
+ - `$bt` removed
  - `$sql_templates` renamed to `$template_select`, `$template_insert` etc.
  - `options()`, `options_insert()`, `options_replace` renamed to `option($option, $mode)`
  - `del()` renamed to `reset()`

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -96,7 +96,7 @@ which case you do not have to define "use" block::
 You can specify some of the expression properties through first argument
 of the constructor::
 
-    $expr = new Expression(["NOW()", 'escapeChar' => '*']);
+    $expr = new Expression(["NOW()", 'connection' => $pdo]);
 
 :ref:`Scroll down <properties>` for full list of properties.
 
@@ -302,8 +302,7 @@ circumstances.
 
 .. php:method:: _escape($sql_code)
 
-  Surrounds `$sql code` with :php:attr:`$escapeChar`.
-  If escapeChar is `null` will do nothing.
+  Surrounds `$sql code` with back-tick
 
   Will also do nothing if it finds "*", "." or "(" character in `$sql_code`::
 
@@ -334,10 +333,6 @@ Other Properties
 .. php:attr:: connection
 
     PDO connection object or any other DB connection object.
-
-.. php:attr:: escapeChar
-
-    Field and table names are escaped using escapeChar which by default is: *`*.
 
 .. php:attr:: paramBase
 

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -302,12 +302,18 @@ circumstances.
 
 .. php:method:: _escape($sql_code)
 
-  Surrounds `$sql code` with back-tick
+  Always surrounds `$sql code` with back-ticks.
 
-  Will also do nothing if it finds "*", "." or "(" character in `$sql_code`::
+.. php:method:: _escapeSoft($sql_code)
+
+  Surrounds `$sql code` with back-ticks.
+
+  It will smartly escape table.field type of strings resulting in `table`.`field`.
+
+  Will do nothing if it finds "*", "`" or "(" character in `$sql_code`::
 
       $query->_escape('first_name');  // `first_name`
-      $query->_escape('first.name');  // first.name
+      $query->_escape('first.name');  // `first`.`name`
       $query->_escape('(2+2)');       // (2+2)
       $query->_escape('*');           // *
 

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -274,17 +274,15 @@ Method can be executed several times on the same Query object.
 Setting Fields
 --------------
 
-.. php:method:: field($fields, $table = null, $alias = null)
+.. php:method:: field($fields, $alias = null)
 
     Adds additional field that you would like to query. If never called,
     will default to :php:attr:`defaultField`, which normally is `*`.
 
     This method has several call options. $field can be array of fields
-    and also can be an :php:class:`Expression`. If you specify expression
-    in $field then alias is mandatory.
+    and also can be an :php:class:`Expression` or :php:class:`Query`
 
     :param string|array|object $fields: Specify list of fields to fetch
-    :param string $table: Optionally specify a table to query from
     :param string $alias: Optionally specify alias of field in resulting query
     :returns: $this
 
@@ -299,16 +297,16 @@ Basic Examples::
     $query->field('first_name,last_name');
         // SELECT `first_name`,`last_name` from `user`
 
-    $query->field('first_name','employee')
+    $query->field('employee.first_name')
         // SELECT `employee`.`first_name` from `user`
 
-    $query->field('first_name',null,'name')
+    $query->field('first_name','name')
         // SELECT `first_name` `name` from `user`
 
     $query->field(['name'=>'first_name'])
         // SELECT `first_name` `name` from `user`
 
-    $query->field(['name'=>'first_name'],'employee');
+    $query->field(['name'=>'employee.first_name']);
         // SELECT `employee`.`first_name` `name` from `user`
 
 If the first parameter of field() method contains non-alphanumeric values
@@ -324,6 +322,9 @@ used as aliases (if they are specified)::
 
     $query->field(['time_now'=>'now()', 'time_created']);
         // SELECT now() `time_now`, `time_created` ...
+
+    $query->field($query->dsql()->table('user')->field('max(age)'), 'max_age');
+        // SELECT (SELECT max(age) from user) `max_age` ...
 
 Method can be executed several times on the same Query object.
 

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -294,7 +294,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         }
 
         if (is_string($value) && strpos($value, '.') !== false) {
-            return implode('.', $this->_escapeSoft(explode('.', $value)));
+            return implode('.', array_map(__METHOD__, explode('.', $value)));
         }
 
         // in some cases we should not escape
@@ -327,7 +327,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         }
 
         // in all other cases we should escape
-        return '`' . str_replace('`', '``', $value) . '`';
+        return '`' . str_replace('`', '``', trim($value)) . '`';
     }
 
     /**
@@ -372,7 +372,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
             '/\[[a-z0-9_]*\]|{[a-z0-9_]*}/',
             function ($matches) use (&$nameless_count) {
 
-                $identifier = substr($matches[0],1,-1);
+                $identifier = substr($matches[0], 1, -1);
                 $escaping = ($matches[0][0] == '[')?'param':'escape';
 
                 // Allow template to contain []

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -349,20 +349,24 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         }
 
         $res= preg_replace_callback(
-            '/\[([a-z0-9_]*)\]/',
+            '/\[[a-z0-9_]*\]|{[a-z0-9_]*}/',
             function ($matches) use (&$nameless_count) {
 
+                $identifier = substr($matches[0],1,-1);
+                $escaping = ($matches[0][0] == '[')?'param':'escape';
+
                 // Allow template to contain []
-                $identifier = $matches[1];
                 if ($identifier === "") {
                     $identifier = $nameless_count++;
+
+                    // use rendering only with named tags
                 }
+                    $fx = '_render_'.$identifier;
 
                 // [foo] will attempt to call $this->_render_foo()
-                $fx = '_render_'.$matches[1];
 
                 if (array_key_exists($identifier, $this->args['custom'])) {
-                    return $this->_consume($this->args['custom'][$identifier]);
+                    return $this->_consume($this->args['custom'][$identifier], $escaping);
                 } elseif (method_exists($this, $fx)) {
                     return $this->$fx();
                 }

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -327,7 +327,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         }
 
         // in all other cases we should escape
-        return '`' . str_replace('`', '``', trim($value)) . '`';
+        return '`' . str_replace('`', '``', $value) . '`';
     }
 
     /**

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -277,7 +277,10 @@ class Expression implements \ArrayAccess, \IteratorAggregate
     /**
      * Soft-escaping SQL identifier. This method will attempt to
      * put `..` around the identifier, however will not do so
-     * if you are using special characters like ".", "(" or "`"
+     * if you are using special characters like ".", "(" or "`".
+     *
+     * It will smartly escape table.field type of strings resulting
+     * in `table`.`field`.
      *
      * @param mixed $value Any string or array of strings
      *

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -303,7 +303,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
             return $value;
         }
 
-        return '`' . str_replace('`', '``', $value) . '`';
+        return '`' . trim($value) . '`';
     }
 
     /**

--- a/src/Query.php
+++ b/src/Query.php
@@ -139,9 +139,9 @@ class Query extends Expression
             return $this;
         }
         if (is_null($alias)) {
-            $this->args['fields'][] = $field;
+            $this->args['field'][] = $field;
         } else {
-            $this->args['fields'][$alias] = $field;
+            $this->args['field'][$alias] = $field;
         }
 
         return $this;
@@ -158,7 +158,7 @@ class Query extends Expression
         $ret = [];
 
         // If no fields were defined, use defaultField
-        if (empty($this->args['fields'])) {
+        if (empty($this->args['field'])) {
             if ($this->defaultField instanceof Expression) {
                 return $this->_consume($this->defaultField);
             }
@@ -166,7 +166,7 @@ class Query extends Expression
         }
 
         // process each defined field
-        foreach ($this->args['fields'] as $alias => $field) {
+        foreach ($this->args['field'] as $alias => $field) {
             // Do not use alias, if it's same as field
             if ($alias === $field) {
                 $alias = null;

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -281,39 +281,48 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
             PHPUnitUtil::callProtectedMethod($this->e(), '_escape', ['first_name'])
         );
         $this->assertEquals(
-            '*first_name*',
-            PHPUnitUtil::callProtectedMethod($this->e(['escapeChar' => '*']), '_escape', ['first_name'])
-        );
-        $this->assertEquals(
             '`123`',
             PHPUnitUtil::callProtectedMethod($this->e(), '_escape', [123])
+        );
+        $this->assertEquals(
+            '`he``llo`',
+            PHPUnitUtil::callProtectedMethod($this->e(), '_escape', ['he`llo'])
         );
 
         // should not escape expressions
         $this->assertEquals(
             '*',
+            PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', ['*'])
+        );
+        $this->assertEquals(
+            '`*`',
             PHPUnitUtil::callProtectedMethod($this->e(), '_escape', ['*'])
         );
         $this->assertEquals(
             '(2+2) age',
+            PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', ['(2+2) age'])
+        );
+        $this->assertEquals(
+            '`(2+2) age`',
             PHPUnitUtil::callProtectedMethod($this->e(), '_escape', ['(2+2) age'])
         );
         $this->assertEquals(
-            'first_name.table',
-            PHPUnitUtil::callProtectedMethod($this->e(), '_escape', ['first_name.table'])
-        );
-        $this->assertEquals(
-            'first#name',
-            PHPUnitUtil::callProtectedMethod($this->e(['escapeChar'=>'#']), '_escape', ['first#name'])
+            '`first_name`.`table`',
+            PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', ['first_name.table'])
         );
         $this->assertEquals(
             true,
-            PHPUnitUtil::callProtectedMethod($this->e(), '_escape', [new \stdClass()]) instanceof \stdClass
+            PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', [new \stdClass()]) instanceof \stdClass
         );
 
         // escaping array - escapes each of its elements
         $this->assertEquals(
             ['`first_name`', '*', '`last_name`'],
+            PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', [ ['first_name', '*', 'last_name'] ])
+        );
+
+        $this->assertEquals(
+            ['`first_name`', '`*`', '`last_name`'],
             PHPUnitUtil::callProtectedMethod($this->e(), '_escape', [ ['first_name', '*', 'last_name'] ])
         );
     }

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -141,6 +141,10 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
         $e = $this->e('hello, [who]', ['who' => 'world']);
         $this->assertEquals('hello, :a', $e->render());
         $this->assertEquals('world', $e->params[':a']);
+
+        $e = $this->e('hello, {who}', ['who' => 'world']);
+        $this->assertEquals('hello, `world`', $e->render());
+        $this->assertEquals([], $e->params);
     }
 
     /**

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -119,15 +119,15 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
             'now()',
             $this->e(['template' => 'now()'])->render()
         );
-        // pass as array without key and custom escapeChar
+        // pass as array without key 
         $this->assertEquals(
             ':a Name',
-            $this->e(['[] Name', 'escapeChar' => '*'], ['First'])->render()
+            $this->e(['[] Name'], ['First'])->render()
         );
-        // pass as array with template key and custom escapeChar
+        // pass as array with template key
         $this->assertEquals(
             ':a Name',
-            $this->e(['template' => '[] Name', 'escapeChar' => '*'], ['Last'])->render()
+            $this->e(['template' => '[] Name'], ['Last'])->render()
         );
     }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -71,6 +71,10 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             PHPUnitUtil::callProtectedMethod($this->q()->field('first_name'), '_render_field')
         );
         $this->assertEquals(
+            '`last_name` `a`',
+            PHPUnitUtil::callProtectedMethod($this->q()->field('first_name','a')->field('last_name','a'), '_render_field')
+        );
+        $this->assertEquals(
             '`first_name`,`last_name`',
             PHPUnitUtil::callProtectedMethod($this->q()->field('first_name,last_name'), '_render_field')
         );

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -79,6 +79,22 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             PHPUnitUtil::callProtectedMethod($this->q()->field('first_name,last_name'), '_render_field')
         );
         $this->assertEquals(
+            '`first_name`,`last_name`',
+            PHPUnitUtil::callProtectedMethod($this->q()->field('first_name')->field('last_name'), '_render_field')
+        );
+        $this->assertEquals(
+            '`last_name`',
+            PHPUnitUtil::callProtectedMethod($this->q()->field('first_name')->reset('field')->field('last_name'), '_render_field')
+        );
+        $this->assertEquals(
+            '*',
+            PHPUnitUtil::callProtectedMethod($this->q()->field('first_name')->reset('field'), '_render_field')
+        );
+        $this->assertEquals(
+            '*',
+            PHPUnitUtil::callProtectedMethod($this->q()->field('first_name')->reset(), '_render_field')
+        );
+        $this->assertEquals(
             '`employee`.`first_name`',
             PHPUnitUtil::callProtectedMethod($this->q()->field('employee.first_name'), '_render_field')
         );

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -71,10 +71,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             PHPUnitUtil::callProtectedMethod($this->q()->field('first_name'), '_render_field')
         );
         $this->assertEquals(
-            '`last_name` `a`',
-            PHPUnitUtil::callProtectedMethod($this->q()->field('first_name','a')->field('last_name','a'), '_render_field')
-        );
-        $this->assertEquals(
             '`first_name`,`last_name`',
             PHPUnitUtil::callProtectedMethod($this->q()->field('first_name,last_name'), '_render_field')
         );
@@ -203,6 +199,17 @@ class QueryTest extends \PHPUnit_Framework_TestCase
      * @covers ::table
      * @expectedException Exception
      */
+    public function testFieldException1()
+    {
+        $this->q()->field('name', 'a')->field('surname', 'a');
+    }
+
+    /**
+     * There shouldn't be alias when passing multiple tables
+     *
+     * @covers ::table
+     * @expectedException Exception
+     */
     public function testTableException1()
     {
         $this->q()->table('employee,jobs', 'u');
@@ -220,25 +227,13 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Alias is mandatory when pass table as Expression
+     * Alias is NOT mandatory when pass table as Expression
      *
      * @covers ::table
-     * @expectedException Exception
      */
     public function testTableException3()
     {
         $this->q()->table($this->q()->expr('test'));
-    }
-
-    /**
-     * Alias is mandatory when pass table as any object
-     *
-     * @covers ::table
-     * @expectedException Exception
-     */
-    public function testTableException4()
-    {
-        $this->q()->table(new \stdClass());
     }
 
     /**
@@ -454,6 +449,13 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             'select `name` from (select * from `employee`) `e`',
             $this->q()
                 ->field('name')->table($q, 'e')
+                ->render()
+        );
+
+        $this->assertEquals(
+            'select `name` from `myt``able`',
+            $this->q()
+                ->field('name')->table(new Expression('{}', ['myt`able']))
                 ->render()
         );
 


### PR DESCRIPTION
## Added {tag} support:
```
new Expression('hello {tag}', ['world']);
```

now generates:

```
hello `world`
```

## refactored _escape

_escape now very strictly escapes it's argument (or array) by adding back-tick.

## added _escapeSoft

Emulates how old _escape worked but also added support for changing 
```
user.name
```
into
```
`user`.`name`
```

You can also call _consume($arg, 'soft-escape');

## removed second argument from field()

Now field always uses ($what, $alias). If you nee to specify table simply use field('table.field');

## refactored table() and it's rendering a bit

Mainly to allow use expression as a table without punishment (queries should still be aliased)

## removed $escapeChar

## Updated documentation. 