### PR TITLE
Feature/support field names with spaces

### DIFF
--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -300,6 +300,21 @@ circumstances.
       $query->_consume('first_name');  // `first_name`
       $query->_consume($other_query);  // will merge parameters and return string
 
+.. php:method:: escape($sql_code)
+
+  Creates new expression where $sql_code appears escaped. Use this method as a
+  conventional means of specifying arguments when you think they might have
+  a nasty back-ticks or commas in the field names. I generally **discourage** you
+  form using this method. Example use would be::
+
+      $query->field('foo,bar');  // escapes and adds 2 fields to the query
+      $query->field($query->escape('foo,bar')); // adds field `foo,bar` to the query
+      $query->field(['foo,bar']);  // adds single field `foo,bar` 
+
+      $query->order('foo desc');  // escapes and `foo` desc to the query
+      $query->field($query->escape('foo desc')); // adds field `foo desc` to the query
+      $query->field(['foo desc']); // adds `foo` desc anyway
+
 .. php:method:: _escape($sql_code)
 
   Always surrounds `$sql code` with back-ticks.

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -19,7 +19,7 @@ class Exception extends \Exception
     public function __construct(
         $message = "",
         $code = 0,
-        Throwable $previous = null
+        \Throwable $previous = null
     ) {
         if (is_array($message)) {
             // message contain additional parameters

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -275,9 +275,9 @@ class Expression implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Soft-escaping SQL identifier. This method will attempt to
-     * put `..` around the identifier, however will not do so
-     * if you are using special characters like ".", "(" or "`".
+     * Soft-escaping SQL identifier. This method will attempt to put
+     * backticks around the identifier, however will not do so if you
+     * are using special characters like ".", "(" or "`".
      *
      * It will smartly escape table.field type of strings resulting
      * in `table`.`field`.

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -309,6 +309,11 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         return '`' . trim($value) . '`';
     }
 
+    public function escape($value)
+    {
+        return $this->expr('{}', [$value]);
+    }
+
     /**
      * Escapes argument by adding backticks around it.
      * This will allow you to use reserved SQL words as table or field

--- a/src/Query.php
+++ b/src/Query.php
@@ -210,7 +210,7 @@ class Query extends Expression
 
     // {{{ Table specification and rendering
     /**
-     * @todo Method description
+     * Specify a table to be used in a query.
      *
      * @param mixed  $table
      * @param string $alias

--- a/src/Query.php
+++ b/src/Query.php
@@ -1108,7 +1108,6 @@ class Query extends Expression
             }
         }
 
-
         if (is_bool($desc)) {
             $desc = $desc ? 'desc' : '';
         } elseif (strtolower($desc) === 'asc') {

--- a/src/Query.php
+++ b/src/Query.php
@@ -1099,13 +1099,15 @@ class Query extends Expression
 
         // First argument may contain space, to divide field and ordering keyword.
         // Explode string only if ordering keyword is 'desc' or 'asc'.
-        if (is_string($order) && strpos($order, ' ') !== false && is_null($desc)) {
-            list($_order, $_desc) = array_map('trim', explode(' ', trim($order), 2));
-            if (in_array(strtolower($_desc), ['desc', 'asc'])) {
-                $order = $_order;
+        if (is_null($desc) && is_string($order) && strpos($order, ' ') !== false) {
+            $_chunks = explode(' ', $order);
+            $_desc = strtolower(array_pop($_chunks));
+            if (in_array($_desc, ['desc', 'asc'])) {
+                $order = implode(' ', $_chunks);
                 $desc = $_desc;
             }
         }
+
 
         if (is_bool($desc)) {
             $desc = $desc ? 'desc' : '';

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -272,6 +272,7 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
      * Fully covers _escape method
      *
      * @covers ::_escape
+     * @covers ::escape
      */
     public function testEscape()
     {
@@ -319,15 +320,29 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
             PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', [new \stdClass()]) instanceof \stdClass
         );
 
-        // escaping array - escapes each of its elements
+        // escaping array - escapes each of its elements using hard escape
         $this->assertEquals(
             ['`first_name`', '*', '`last_name`'],
             PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', [ ['first_name', '*', 'last_name'] ])
         );
 
+        // escaping array - escapes each of its elements using hard escape
         $this->assertEquals(
             ['`first_name`', '`*`', '`last_name`'],
             PHPUnitUtil::callProtectedMethod($this->e(), '_escape', [ ['first_name', '*', 'last_name'] ])
+        );
+
+        $this->assertEquals(
+            '`first_name`',
+            $this->e()->escape('first_name')->render()
+        );
+        $this->assertEquals(
+            '`first``_name`',
+            $this->e()->escape('first`_name')->render()
+        );
+        $this->assertEquals(
+            '`first``_name {}`',
+            $this->e()->escape('first`_name {}')->render()
         );
     }
 

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -119,7 +119,7 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
             'now()',
             $this->e(['template' => 'now()'])->render()
         );
-        // pass as array without key 
+        // pass as array without key
         $this->assertEquals(
             ':a Name',
             $this->e(['[] Name'], ['First'])->render()
@@ -307,8 +307,12 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
             PHPUnitUtil::callProtectedMethod($this->e(), '_escape', ['(2+2) age'])
         );
         $this->assertEquals(
-            '`first_name`.`table`',
-            PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', ['first_name.table'])
+            '`users`.`first_name`',
+            PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', ['users.first_name'])
+        );
+        $this->assertEquals(
+            '`users`.*',
+            PHPUnitUtil::callProtectedMethod($this->e(), '_escapeSoft', ['users.*'])
         );
         $this->assertEquals(
             true,

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -924,6 +924,26 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             'order by `this is жук` desc',
             $this->q('[order]')->order('this is жук desc')->render()
         );
+        $this->assertEquals(
+            'order by * desc',
+            $this->q('[order]')->order(['* desc'])->render()
+        );
+        $this->assertEquals(
+            'order by `{}` desc',
+            $this->q('[order]')->order(['{} desc'])->render()
+        );
+        $this->assertEquals(
+            'order by `* desc`',
+            $this->q('[order]')->order(new Expression('`* desc`'))->render()
+        );
+        $this->assertEquals(
+            'order by `* desc`',
+            $this->q('[order]')->order($this->q()->escape('* desc'))->render()
+        );
+        $this->assertEquals(
+            'order by `* desc {}`',
+            $this->q('[order]')->order($this->q()->escape('* desc {}'))->render()
+        );
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -909,8 +909,8 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         );
         // strange field names
         $this->assertEquals(
-            'order by `na``me` desc',
-            $this->q('[order]')->order('na`me desc')->render()
+            'order by `my name` desc',
+            $this->q('[order]')->order('`my name` desc')->render()
         );
         $this->assertEquals(
             'order by `жук`',
@@ -957,8 +957,8 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         );
         // strange field names
         $this->assertEquals(
-            'group by `na``me`',
-            $this->q('[group]')->group('na`me')->render()
+            'group by `my name`',
+            $this->q('[group]')->group('`my name`')->render()
         );
         $this->assertEquals(
             'group by `жук`',

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -345,19 +345,19 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'select `na``me` from `employee`',
             $this->q()
-                ->field(new Expression('{}',['na`me']))->table('employee')
+                ->field(new Expression('{}', ['na`me']))->table('employee')
                 ->render()
         );
         $this->assertEquals(
             'select `жук` from `employee`',
             $this->q()
-                ->field(new Expression('{}',['жук']))->table('employee')
+                ->field(new Expression('{}', ['жук']))->table('employee')
                 ->render()
         );
         $this->assertEquals(
             'select `this is 💩` from `employee`',
             $this->q()
-                ->field(new Expression('{}',['this is 💩']))->table('employee')
+                ->field(new Expression('{}', ['this is 💩']))->table('employee')
                 ->render()
         );
 
@@ -902,6 +902,28 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             'order by `name` desc, `surname`',
             $this->q('[order]')->order('surname')->order('name desc')->render()
         );
+        // table name|alias included
+        $this->assertEquals(
+            'order by `users`.`name`',
+            $this->q('[order]')->order('users.name')->render()
+        );
+        // strange field names
+        $this->assertEquals(
+            'order by `na``me` desc',
+            $this->q('[order]')->order('na`me desc')->render()
+        );
+        $this->assertEquals(
+            'order by `жук`',
+            $this->q('[order]')->order('жук asc')->render()
+        );
+        $this->assertEquals(
+            'order by `this is 💩`',
+            $this->q('[order]')->order('this is 💩')->render()
+        );
+        $this->assertEquals(
+            'order by `this is жук` desc',
+            $this->q('[order]')->order('this is жук desc')->render()
+        );
     }
 
     /**
@@ -927,6 +949,28 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'group by `gender`, `age`',
             $this->q('[group]')->group('gender')->group('age')->render()
+        );
+        // table name|alias included
+        $this->assertEquals(
+            'group by `users`.`gender`',
+            $this->q('[group]')->group('users.gender')->render()
+        );
+        // strange field names
+        $this->assertEquals(
+            'group by `na``me`',
+            $this->q('[group]')->group('na`me')->render()
+        );
+        $this->assertEquals(
+            'group by `жук`',
+            $this->q('[group]')->group('жук')->render()
+        );
+        $this->assertEquals(
+            'group by `this is 💩`',
+            $this->q('[group]')->group('this is 💩')->render()
+        );
+        $this->assertEquals(
+            'group by `this is жук`',
+            $this->q('[group]')->group('this is жук')->render()
         );
     }
 


### PR DESCRIPTION
* group by and order by now uses soft-escape
* added few test cases for that
* order by will no more try to explode string by dot, soft-escape does that in rendering phase
* order by tries to be smart when exploding field name by space and searching for ordering keyword. It'll only explode if correct ordering keyword is actually found at the end of string.
* added test cases for group by and order by with strange field names.

resolves #64 