### PR TITLE
Add argument to getDSQLExpression (for expressionable)

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -249,7 +249,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
 
         // User may add Expressionable trait to any class, then pass it's objects
         if ($sql_code instanceof Expressionable) {
-            $sql_code = $sql_code->getDSQLExpression();
+            $sql_code = $sql_code->getDSQLExpression($this);
         }
 
         if (!$sql_code instanceof Expression) {

--- a/src/Expressionable.php
+++ b/src/Expressionable.php
@@ -8,5 +8,5 @@ namespace atk4\dsql;
  */
 interface Expressionable
 {
-    public function getDSQLExpression();
+    public function getDSQLExpression($expression);
 }

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -536,9 +536,9 @@ class JsonExpression extends Expression
     }
 }
 class MyField implements Expressionable {
-    function getDSQLExpression()
+    function getDSQLExpression($e)
     {
-        return new Expression('`myfield`');
+        return $e->expr('`myfield`');
     }
 }
 // @codingStandardsIgnoreEnd


### PR DESCRIPTION
It's better when Expressionable's method getDSQLExpression would actually get that the parent's DSQL as an argument. 

This way we know in which context the object is being rendered.