### PR TITLE
Add detection for double set() and throw exception

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -827,7 +827,7 @@ class Query extends Expression
         if (is_string($field) || $field instanceof Expression || $field instanceof Expressionable) {
             if (is_string($field)) {
                 if (isset($this->args['set']['_set_duplicate_verification'][$field])) {
-                    throw new Exception(['Calling set() multiple times for same field can cause problems. If it is intentional, use expression as field name', 'field'=>$field]);
+                    throw new Exception(['Calling set() multiple times for same field can cause problems. If it is intentional, use expression as field name', 'field' => $field]);
                 }
                 $this->args['set']['_set_duplicate_verification'][$field] = true;
             }
@@ -850,7 +850,7 @@ class Query extends Expression
         $ret = [];
 
         if ($this->args['set']) {
-            foreach ($this->args['set'] as $couple){
+            foreach ($this->args['set'] as $couple) {
                 if (!isset($couple[0])) {
                     continue;
                 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -825,6 +825,12 @@ class Query extends Expression
         }
 
         if (is_string($field) || $field instanceof Expression || $field instanceof Expressionable) {
+            if (is_string($field)) {
+                if (isset($this->args['set']['_set_duplicate_verification'][$field])) {
+                    throw new Exception(['Calling set() multiple times for same field can cause problems. If it is intentional, use expression as field name', 'field'=>$field]);
+                }
+                $this->args['set']['_set_duplicate_verification'][$field] = true;
+            }
             $this->args['set'][] = [$field, $value];
         } else {
             throw new Exception('Field name should be string or Expressionable in '.__METHOD__);
@@ -844,7 +850,11 @@ class Query extends Expression
         $ret = [];
 
         if ($this->args['set']) {
-            foreach ($this->args['set'] as list($field, $value)) {
+            foreach ($this->args['set'] as $couple){
+                if (!isset($couple[0])) {
+                    continue;
+                }
+                list($field, $value) = $couple;
                 $field = $this->_consume($field, 'escape');
                 $value = $this->_consume($value, 'param');
 
@@ -867,7 +877,11 @@ class Query extends Expression
 
 
         if ($this->args['set']) {
-            foreach ($this->args['set'] as list($field, $value)) {
+            foreach ($this->args['set'] as $couple) {
+                if (!isset($couple[0])) {
+                    continue;
+                }
+                list($field, $value) = $couple;
                 $field = $this->_consume($field, 'escape');
 
                 $ret[] = $field;
@@ -888,7 +902,11 @@ class Query extends Expression
         $ret = [];
 
         if ($this->args['set']) {
-            foreach ($this->args['set'] as list($field, $value)) {
+            foreach ($this->args['set'] as $couple) {
+                if (!isset($couple[0])) {
+                    continue;
+                }
+                list($field, $value) = $couple;
                 $value = $this->_consume($value, 'param');
 
                 $ret[] = $value;

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1443,7 +1443,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test Double-Set prevention
+     * Test Double-Set prevention.
      *
      * @covers \atk4\dsql\Query::set
      * @covers \atk4\dsql\Query::_render_set
@@ -1455,36 +1455,32 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         // Double Update
         $q = $this->q()->table('user')
             ->set($this->q()->escape('name'), 'John')
-            ->set($this->q()->escape('name'), 'Peter')
-            ;
+            ->set($this->q()->escape('name'), 'Peter');
         $this->assertEquals('update `user` set `name`=:a, `name`=:b', $q->mode('update')->render());
 
         // Double Insert
         $q = $this->q()->table('user')
             ->set($this->q()->escape('name'), 'John')
-            ->set($this->q()->escape('name'), 'Peter')
-            ;
+            ->set($this->q()->escape('name'), 'Peter');
         $this->assertEquals('insert into `user` (`name`,`name`) values (:a,:b)', $q->mode('insert')->render());
-    
+
         // Double Insert
         $q = $this->q()->table('user')
             ->set('name', 'John')
             ->reset('set')
-            ->set('name', 'Peter')
-            ;
+            ->set('name', 'Peter');
         $this->assertEquals('insert into `user` (`name`) values (:a)', $q->mode('insert')->render());
 
         // Double Insert
         $q = $this->q()->table('user')
             ->set('name', 'John')
             ->reset()->table('user')
-            ->set('name', 'Peter')
-            ;
+            ->set('name', 'Peter');
         $this->assertEquals('insert into `user` (`name`) values (:a)', $q->mode('insert')->render());
     }
 
     /**
-     * Test Double-Set prevention
+     * Test Double-Set prevention.
      *
      * @expectedException Exception
      */
@@ -1492,11 +1488,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     {
         $q = $this->q()->table('user')
             ->set('name', 'John')
-            ->set('name', 'Peter')
-            ;
+            ->set('name', 'Peter');
         $this->assertEquals('insert into `user` (`name`,`name`) values (:a,:b)', $q->mode('insert')->render());
     }
-
 
     /**
      * Test [option].

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1443,6 +1443,62 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test Double-Set prevention
+     *
+     * @covers \atk4\dsql\Query::set
+     * @covers \atk4\dsql\Query::_render_set
+     * @covers \atk4\dsql\Query::_render_set_values
+     * @covers \atk4\dsql\Query::_render_set_fields
+     */
+    public function testDoubleSet()
+    {
+        // Double Update
+        $q = $this->q()->table('user')
+            ->set($this->q()->escape('name'), 'John')
+            ->set($this->q()->escape('name'), 'Peter')
+            ;
+        $this->assertEquals('update `user` set `name`=:a, `name`=:b', $q->mode('update')->render());
+
+        // Double Insert
+        $q = $this->q()->table('user')
+            ->set($this->q()->escape('name'), 'John')
+            ->set($this->q()->escape('name'), 'Peter')
+            ;
+        $this->assertEquals('insert into `user` (`name`,`name`) values (:a,:b)', $q->mode('insert')->render());
+    
+        // Double Insert
+        $q = $this->q()->table('user')
+            ->set('name', 'John')
+            ->reset('set')
+            ->set('name', 'Peter')
+            ;
+        $this->assertEquals('insert into `user` (`name`) values (:a)', $q->mode('insert')->render());
+
+        // Double Insert
+        $q = $this->q()->table('user')
+            ->set('name', 'John')
+            ->reset()->table('user')
+            ->set('name', 'Peter')
+            ;
+        $this->assertEquals('insert into `user` (`name`) values (:a)', $q->mode('insert')->render());
+    }
+
+    /**
+     * Test Double-Set prevention
+     *
+     * @expectedException Exception
+     */
+    public function testDoubleSetE2()
+    {
+        $q = $this->q()->table('user')
+            ->set('name', 'John')
+            ->set('name', 'Peter')
+            ;
+        $this->assertEquals('insert into `user` (`name`,`name`) values (:a,:b)', $q->mode('insert')->render());
+    }
+
+
+    /**
      * Test [option].
      *
      * @covers ::option


### PR DESCRIPTION
When #100 was merged, it allowed executing set() multiple times on the same field. Due to bugs in "Agile Data," this have caused a change in the behaviour.

I think that using set() on same field multiple times is incorrect in the first place and exception should be generated. This PR implements this check.

You can still use 1st argument expression to bypass the check. 