### PR TITLE
Add support for URI-style DNS: mysql://user:pass@host/db

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -51,6 +51,20 @@ class Connection
         }
         list($driver, $rest) = explode(':', $dsn, 2);
 
+        // Try to dissect DSN into parts
+        if (is_array($dsn)) {
+            $parts = $dsn;
+        } else {
+            $parts = parse_url($dsn);
+        }
+        // If parts are usable, convert DSN format
+        if ($parts !== false && isset($parts['host']) && isset($parts['path']) && $user === null && $password === null) {
+            // DSN is using URL-like format, so we need to convert it
+            $dsn = $parts['scheme'].':host='.$parts['host'].';dbname='.substr($parts['path'], 1);
+            $user = $parts['user'];
+            $password = $parts['pass'];
+        }
+
         switch (strtolower($driver)) {
             case 'mysql':
                 return new self(array_merge([


### PR DESCRIPTION
Even though the change was dane in here https://github.com/atk4/data/blob/848e60ad47d47716ce4a25c1dbaaf53f76c5ff0f/src/Persistence.php#L32, this wasn't done on DSQL level and therefore something like this wasn't possible:

```
$db = \atk4\data\Persistence::connect('dumper:mysql://root:root@localhost/test');
```

With this fix now it is possible as well as using mysql:// with DSQL-only applications.