### PR TITLE
Add verification for foreign objects inside where() values

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -586,9 +586,9 @@ class Query extends Expression
             case 2:
                 if (is_object($cond) && !$cond instanceof Expressionable && !$cond instanceof Expression) {
                     throw new Exception([
-                        'Value cannot be converted to SQL-compatible expression', 
-                        'field'=>$field,
-                        'value'=>$cond,
+                        'Value cannot be converted to SQL-compatible expression',
+                        'field'=> $field,
+                        'value'=> $cond,
                     ]);
                 }
 
@@ -597,10 +597,10 @@ class Query extends Expression
             case 3:
                 if (is_object($value) && !$value instanceof Expressionable && !$value instanceof Expression) {
                     throw new Exception([
-                        'Value cannot be converted to SQL-compatible expression', 
-                        'field'=>$field,
-                        'cond'=>$cond,
-                        'value'=>$value,
+                        'Value cannot be converted to SQL-compatible expression',
+                        'field'=> $field,
+                        'cond' => $cond,
+                        'value'=> $value,
                     ]);
                 }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -584,9 +584,26 @@ class Query extends Expression
                 $this->args[$kind][] = [$field];
                 break;
             case 2:
+                if (is_object($cond) && !$cond instanceof Expressionable && !$cond instanceof Expression) {
+                    throw new Exception([
+                        'Value cannot be converted to SQL-compatible expression', 
+                        'field'=>$field,
+                        'value'=>$cond,
+                    ]);
+                }
+
                 $this->args[$kind][] = [$field, $cond];
                 break;
             case 3:
+                if (is_object($value) && !$value instanceof Expressionable && !$value instanceof Expression) {
+                    throw new Exception([
+                        'Value cannot be converted to SQL-compatible expression', 
+                        'field'=>$field,
+                        'cond'=>$cond,
+                        'value'=>$value,
+                    ]);
+                }
+
                 $this->args[$kind][] = [$field, $cond, $value];
                 break;
         }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -806,7 +806,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Verify that passing garbage to where throw exception
+     * Verify that passing garbage to where throw exception.
      *
      * @covers ::order
      * @expectedException Exception
@@ -817,7 +817,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Verify that passing garbage to where throw exception
+     * Verify that passing garbage to where throw exception.
      *
      * @covers ::order
      * @expectedException Exception
@@ -828,7 +828,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Verify that passing garbage to where throw exception
+     * Verify that passing garbage to where throw exception.
      *
      * @covers ::order
      * @expectedException Exception

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -806,6 +806,39 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Verify that passing garbage to where throw exception
+     *
+     * @covers ::order
+     * @expectedException Exception
+     */
+    public function testWhereIncompatibleObject1()
+    {
+        $this->q('[where]')->where('a', new \DateTime())->render();
+    }
+
+    /**
+     * Verify that passing garbage to where throw exception
+     *
+     * @covers ::order
+     * @expectedException Exception
+     */
+    public function testWhereIncompatibleObject2()
+    {
+        $this->q('[where]')->where('a', new \DateTime());
+    }
+
+    /**
+     * Verify that passing garbage to where throw exception
+     *
+     * @covers ::order
+     * @expectedException Exception
+     */
+    public function testWhereIncompatibleObject3()
+    {
+        $this->q('[where]')->where('a', '<>', new \DateTime());
+    }
+
+    /**
      * Testing where() with special values - null, array, like.
      *
      * @covers ::where


### PR DESCRIPTION
resolves #121

I have also tested "Agile Data" with this modification on the following test:

``` php
        $a = [
            'user' => [
                1 => ['id' => 1, 'name' => 'John', 'date' => '1981-12-08'],
                2 => ['id' => 2, 'name' => 'Sue', 'date' => '1982-12-08'],
            ], ];
        $this->setDB($a);

        $db = new Persistence_SQL($this->db->connection);
        $m = new Model($db, 'user');
        $m->addField('name');
        $m->addField('date', ['type'=>'date']);

        // successful!!
        $m->tryLoadBy('date', new \DateTime('08-12-1982'));
        $this->assertEquals('Sue', $m['name']);

        // throws error
        $m->tryLoadBy('name', new \DateTime('08-12-1982'));
```

<img width="960" alt="screen shot 2017-12-14 at 14 04 14" src="https://user-images.githubusercontent.com/453929/33996016-b34c2d18-e0d7-11e7-9898-bd5c91839952.png">
