### PR TITLE
Allow fields to be in an SQL query

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -180,7 +180,7 @@ class Query extends Expression
 
             if (is_object($field) && $field instanceof \atk4\data\Field && !$field instanceof Expressionable && !$field instanceof Expression) {
                 // special case for Agile Data Fields, not sure if this is a good code, but some workaround is needed.
-                $ret[] = $field->short_name;
+                $ret[] = $this->_escape($field->short_name);
                 continue;
             }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -178,6 +178,12 @@ class Query extends Expression
                 $alias = null;
             }
 
+            if (is_object($field) && $field instanceof \atk4\data\Field && !$field instanceof Expressionable && !$field instanceof Expression) {
+                // special case for Agile Data Fields, not sure if this is a good code, but some workaround is needed.
+                $ret[] = $field->short_name;
+                continue;
+            }
+
             // Will parameterize the value and backtick if necessary
             $field = $this->_consume($field, 'soft-escape');
 


### PR DESCRIPTION
There is a bit of unclarity with the implementation, so this is a hack to workaround some limitations. This is to be refactored when second major persistence is added to Agile Data, but here is the reasoning.

1. Currently Model Field must implement Expressionable in order to query data from SQL persistence.
2. There no such limitation on Array persistence, any field will be loaded
3. DSQL shouldn't rely on Agile Data. Agile Data field shouldn't rely on DSQL.

So the proper solution here would be to move expressionable into Agile Core and require all model fields to implement it and use it regardless of the database, although it's not realistic until we have a better understanding of how multiple complex (with expressions) persistences co-exist.

The work-around here simply replaces what would be an exception with an acceptable approach field embedding.