### PR TITLE
Feature/oracle lastid

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -298,7 +298,7 @@ class Connection
 
     public $override_last_insert_id = null;
 
-    function lastInsertID()
+    public function lastInsertID()
     {
         if ($this->override_last_insert_id) {
             $id = $this->override_last_insert_id;
@@ -306,6 +306,7 @@ class Connection
 
             return $id;
         }
+
         return $this->connection->lastInsertID();
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -295,4 +295,17 @@ class Connection
 
         return false;
     }
+
+    public $override_last_insert_id = null;
+
+    function lastInsertID()
+    {
+        if ($this->override_last_insert_id) {
+            $id = $this->override_last_insert_id;
+            $this->override_last_insert_id = null;
+
+            return $id;
+        }
+        return $this->connection->lastInsertID();
+    }
 }


### PR DESCRIPTION
YUK, so there is this problem with Oracle:

SQLSTATE[IM001]: Driver does not support this function: driver does not support lastInsertId()

Agile Data can use beforeSave / beforeInsert hook to get sequence number and use it inside insert, but we need ability to specify custom lastInsertID() on DSQL level.

