### PR TITLE
Fix: SQL does not guarantee the order of retreived rows unless explic…

### DIFF
--- a/tests/db/SelectTest.php
+++ b/tests/db/SelectTest.php
@@ -159,11 +159,11 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
             ->insert();
         $this->assertEquals(
             [['id' => 1, 'name' => 'John'], ['id' => 2, 'name' => 'Jane']],
-            $this->q('employee')->field('id,name')->get()
+            $this->q('employee')->field('id,name')->order("id")->get()
         );
         $this->assertEquals(
             [['id' => 1, 'name' => 'John'], ['id' => 2, 'name' => 'Jane']],
-            $this->q('employee')->field('id,name')->select()->fetchAll()
+            $this->q('employee')->field('id,name')->order("id")->select()->fetchAll()
         );
 
         // update
@@ -173,7 +173,7 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
             ->update();
         $this->assertEquals(
             [['id' => 1, 'name' => 'Johnny'], ['id' => 2, 'name' => 'Jane']],
-            $this->q('employee')->field('id,name')->get()
+            $this->q('employee')->field('id,name')->order("id")->get()
         );
 
         // replace

--- a/tests/db/SelectTest.php
+++ b/tests/db/SelectTest.php
@@ -159,11 +159,11 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
             ->insert();
         $this->assertEquals(
             [['id' => 1, 'name' => 'John'], ['id' => 2, 'name' => 'Jane']],
-            $this->q('employee')->field('id,name')->order("id")->get()
+            $this->q('employee')->field('id,name')->order('id')->get()
         );
         $this->assertEquals(
             [['id' => 1, 'name' => 'John'], ['id' => 2, 'name' => 'Jane']],
-            $this->q('employee')->field('id,name')->order("id")->select()->fetchAll()
+            $this->q('employee')->field('id,name')->order('id')->select()->fetchAll()
         );
 
         // update
@@ -173,7 +173,7 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
             ->update();
         $this->assertEquals(
             [['id' => 1, 'name' => 'Johnny'], ['id' => 2, 'name' => 'Jane']],
-            $this->q('employee')->field('id,name')->order("id")->get()
+            $this->q('employee')->field('id,name')->order('id')->get()
         );
 
         // replace


### PR DESCRIPTION
The tests are comparing an array with the data retreived from database. Phpunit will fail if the two arrays are not in the same order.
SQL does not guarantee the order of rows retrieved, unless the 'ORDER BY' is added to the query. 
This pull-request adds the order()-clause to queries.