### PR TITLE
Fix pdo

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -60,7 +60,7 @@ class Connection
         if ($dsn instanceof \PDO) {
             $driver = $dsn->getAttribute(\PDO::ATTR_DRIVER_NAME);
             $connectionClass = '\\atk4\\dsql\\Connection';
-            $queryClass      = null;
+            $queryClass = null;
             $expressionClass = null;
             switch ($driver) {
                 case 'pgsql':

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -81,6 +81,7 @@ class Connection
                     break;
 
             }
+
             return new $connectionClass(array_merge([
                     'connection'       => $dsn,
                     'query_class'      => $queryClass,

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -59,14 +59,16 @@ class Connection
         // If it's already PDO object, then we simply use it
         if ($dsn instanceof \PDO) {
             $driver = $dsn->getAttribute(\PDO::ATTR_DRIVER_NAME);
+            $connectionClass = '\\atk4\\dsql\\Connection';
             $queryClass      = null;
             $expressionClass = null;
             switch ($driver) {
                 case 'pgsql':
+                    $connectionClass = '\\atk4\\dsql\\Connection_PgSQL';
                     $queryClass = 'atk4\dsql\Query_PgSQL';
                     break;
                 case 'oci':
-
+                    $connectionClass = '\\atk4\\dsql\\Connection_Oracle';
                     break;
                 case 'sqlite':
                     $queryClass = 'atk4\dsql\Query_SQLite';
@@ -78,7 +80,7 @@ class Connection
                     break;
 
             }
-            return new static(array_merge([
+            return new $connectionClass(array_merge([
                     'connection'       => $dsn,
                     'query_class'      => $queryClass,
                     'expression_class' => $expressionClass,

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -58,9 +58,30 @@ class Connection
     {
         // If it's already PDO object, then we simply use it
         if ($dsn instanceof \PDO) {
+            $driver = $dsn->getAttribute(\PDO::ATTR_DRIVER_NAME);
+            $queryClass      = null;
+            $expressionClass = null;
+            switch ($driver) {
+                case 'pgsql':
+                    $queryClass = 'atk4\dsql\Query_PgSQL';
+                    break;
+                case 'oci':
+
+                    break;
+                case 'sqlite':
+                    $queryClass = 'atk4\dsql\Query_SQLite';
+                case 'mysql':
+                    $expressionClass = 'atk4\dsql\Expression_MySQL';
+                default:
+                    // Default, for backwards compatibility
+                    $queryClass = 'atk4\dsql\Query_MySQL';
+                    break;
+
+            }
             return new static(array_merge([
-                    'connection'  => $dsn,
-                    'query_class' => 'atk4\dsql\Query_MySQL',
+                    'connection'       => $dsn,
+                    'query_class'      => $queryClass,
+                    'expression_class' => $expressionClass,
                 ], $args));
         }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -72,6 +72,7 @@ class Connection
                     break;
                 case 'sqlite':
                     $queryClass = 'atk4\dsql\Query_SQLite';
+                    break;
                 case 'mysql':
                     $expressionClass = 'atk4\dsql\Expression_MySQL';
                 default:

--- a/tests/db/PdoSelectTest.php
+++ b/tests/db/PdoSelectTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace atk4\dsql\tests\db;
+
+use atk4\dsql\tests\db\SelectTest;
+use atk4\dsql\Connection;
+
+class PdoSelectTest extends SelectTest
+{
+    public function __construct()
+    {
+        $this->c = Connection::connect(new \PDO($GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD']));
+        $this->pdo = $this->c->connection();
+
+        $this->pdo->query(
+            'CREATE TEMPORARY TABLE employee (id int not null, name text, surname text, retired bool, PRIMARY KEY (id))'
+        );
+    }
+}

--- a/tests/db/PdoSelectTest.php
+++ b/tests/db/PdoSelectTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace atk4\dsql\tests\db;
 
 use atk4\dsql\Connection;

--- a/tests/db/PdoSelectTest.php
+++ b/tests/db/PdoSelectTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace atk4\dsql\tests\db;
 
-use atk4\dsql\tests\db\SelectTest;
 use atk4\dsql\Connection;
 
 class PdoSelectTest extends SelectTest

--- a/tests/db/SelectTest.php
+++ b/tests/db/SelectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace atk4\dsql\tests;
+namespace atk4\dsql\tests\db;
 
 use atk4\dsql\Connection;
 use atk4\dsql\Expression;
@@ -10,26 +10,12 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
 {
     protected $pdo;
 
-    /**
-     * The connection returned from Connection::connect using a DSN
-     * @var Connection|\PDO
-     */
-    protected $c;
-
-    /**
-     * An instance of \PDO, created with same credentials as self::$c
-     * @var \PDO
-     */
-    protected $cpdo;
-
     public function __construct()
     {
-        $this->c    = Connection::connect($GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD']);
-        $this->cpdo = Connection::connect(new \PDO($GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD']));
-
+        $this->c = Connection::connect($GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD']);
         $this->pdo = $this->c->connection();
 
-        $this->pdo->query('CREATE TABLE employee (id int not null, name text, surname text, retired bool, PRIMARY KEY (id))');
+        $this->pdo->query('CREATE TEMPORARY TABLE employee (id int not null, name text, surname text, retired bool, PRIMARY KEY (id))');
     }
 
     /**
@@ -48,9 +34,9 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
         return $this->createFlatXMLDataSet(dirname(__FILE__).'/SelectTest.xml');
     }
 
-    private function q($connection, $table = null, $alias = null)
+    private function q($table = null, $alias = null)
     {
-        $q = $connection->dsql();
+        $q = $this->c->dsql();
 
         // add table to query if specified
         if ($table !== null) {
@@ -60,83 +46,70 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
         return $q;
     }
 
-    private function e($connection, $template = null, $args = null)
+    private function e($template = null, $args = null)
     {
-        return $connection->expr($template, $args);
+        return $this->c->expr($template, $args);
     }
 
-    public function connProvider()
-    {
-        return [
-            [$this->c],
-            [$this->cpdo],
-        ];
-    }
-
-    /**
-     * @dataProvider rovider connProvider
-     */
     public function testBasicQueries()
     {
-        foreach ([$this->c, $this->cpdo] as $conn) {
-            $this->assertEquals(4, $this->getConnection()->getRowCount('employee'));
+        $this->assertEquals(4, $this->getConnection()->getRowCount('employee'));
 
+        $this->assertEquals(
+            ['name' => 'Oliver', 'surname' => 'Smith'],
+            $this->q('employee')->field('name,surname')->getRow()
+        );
+
+        $this->assertEquals(
+            ['surname' => 'Taylor'],
+            $this->q('employee')->field('surname')->where('retired', '1')->getRow()
+        );
+
+        $this->assertEquals(
+            4,
+            $this->q()->field(new Expression('2+2'))->getOne()
+        );
+
+        $this->assertEquals(
+            4,
+            $this->q('employee')->field(new Expression('count(*)'))->getOne()
+        );
+
+        $names = [];
+        foreach ($this->q('employee')->where('retired', false) as $row) {
+            $names[] = $row['name'];
+        }
+        $this->assertEquals(
+            ['Oliver', 'Jack', 'Charlie'],
+            $names
+        );
+
+        $this->assertEquals(
+            [['now' => 4]],
+            $this->q()->field(new Expression('2+2'), 'now')->get()
+        );
+
+        /*
+         * Postgresql needs to have values cast, to make the query work.
+         * But CAST(.. AS int) does not work in mysql. So we use two different tests..
+         * (CAST(.. AS int) will work on mariaDB, whereas mysql needs it to be CAST(.. AS signed))
+         */
+        if ('pgsql' === $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
             $this->assertEquals(
-                ['name' => 'Oliver', 'surname' => 'Smith'],
-                $this->q($conn, 'employee')->field('name,surname')->getRow()
+                [['now' => 6]],
+                $this->q()->field(new Expression('CAST([] AS int)+CAST([] AS int)', [3, 3]), 'now')->get()
             );
-
+        } else {
             $this->assertEquals(
-                ['surname' => 'Taylor'],
-                $this->q($conn, 'employee')->field('surname')->where('retired', '1')->getRow()
-            );
-
-            $this->assertEquals(
-                4,
-                $this->q($conn)->field(new Expression('2+2'))->getOne()
-            );
-
-            $this->assertEquals(
-                4,
-                $this->q($conn, 'employee')->field(new Expression('count(*)'))->getOne()
-            );
-
-            $names = [];
-            foreach ($this->q($conn, 'employee')->where('retired', false) as $row) {
-                $names[] = $row['name'];
-            }
-            $this->assertEquals(
-                ['Oliver', 'Jack', 'Charlie'],
-                $names
-            );
-
-            $this->assertEquals(
-                [['now' => 4]],
-                $this->q($conn)->field(new Expression('2+2'), 'now')->get()
-            );
-
-            /*
-             * Postgresql needs to have values cast, to make the query work.
-             * But CAST(.. AS int) does not work in mysql. So we use two different tests..
-             * (CAST(.. AS int) will work on mariaDB, whereas mysql needs it to be CAST(.. AS signed))
-             */
-            if ('pgsql' === $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
-                $this->assertEquals(
-                    [['now' => 6]],
-                    $this->q($conn)->field(new Expression('CAST([] AS int)+CAST([] AS int)', [3, 3]), 'now')->get()
-                );
-            } else {
-                $this->assertEquals(
-                    [['now' => 6]],
-                    $this->q($conn)->field(new Expression('[]+[]', [3, 3]), 'now')->get()
-                );
-            }
-
-            $this->assertEquals(
-                5,
-                $this->q($conn)->field(new Expression('COALESCE([],5)', [null]), 'null_test')->getOne()
+                [['now' => 6]],
+                $this->q()->field(new Expression('[]+[]', [3, 3]), 'now')->get()
             );
         }
+
+        $this->assertEquals(
+            5,
+            $this->q()->field(new Expression('COALESCE([],5)', [null]), 'null_test')->getOne()
+        );
     }
 
     public function testExpression()
@@ -150,12 +123,12 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
         if ('pgsql' === $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
             $this->assertEquals(
                 'foo',
-                $this->e($this->c, 'select CAST([] AS TEXT)', ['foo'])->getOne()
+                $this->e('select CAST([] AS TEXT)', ['foo'])->getOne()
             );
         } else {
             $this->assertEquals(
                 'foo',
-                $this->e($this->c, 'select CAST([] AS CHAR)', ['foo'])->getOne()
+                $this->e('select CAST([] AS CHAR)', ['foo'])->getOne()
             );
         }
     }
@@ -168,20 +141,20 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
         // simple value
         $this->assertEquals(
             'Williams',
-            (string) $this->q($this->c, 'employee')->field('surname')->where('name', 'Jack')
+            (string) $this->q('employee')->field('surname')->where('name', 'Jack')
         );
         // table as sub-query
         $this->assertEquals(
             'Williams',
-            (string) $this->q($this->c, $this->q($this->c, 'employee'), 'e2')->field('surname')->where('name', 'Jack')
+            (string) $this->q($this->q('employee'), 'e2')->field('surname')->where('name', 'Jack')
         );
         // field as expression
         $this->assertEquals(
             'Williams',
-            (string) $this->q($this->c, 'employee')->field($this->e($this->c, 'surname'))->where('name', 'Jack')
+            (string) $this->q('employee')->field($this->e('surname'))->where('name', 'Jack')
         );
         // cast to string multiple times
-        $q = $this->q($this->c, 'employee')->field('surname')->where('name', 'Jack');
+        $q = $this->q('employee')->field('surname')->where('name', 'Jack');
         $this->assertEquals(
             ['Williams', 'Williams'],
             [(string) $q, (string) $q]
@@ -189,52 +162,52 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
         // cast custom Expression to string
         $this->assertEquals(
             '7',
-            (string) $this->e($this->c, 'select 3+4')
+            (string) $this->e('select 3+4')
         );
     }
 
     public function testOtherQueries()
     {
         // truncate table
-        $this->q($this->c, 'employee')->truncate();
+        $this->q('employee')->truncate();
         $this->assertEquals(
             0,
-            $this->q($this->c, 'employee')->field(new Expression('count(*)'))->getOne()
+            $this->q('employee')->field(new Expression('count(*)'))->getOne()
         );
 
         // insert
-        $this->q($this->c, 'employee')
+        $this->q('employee')
             ->set(['id' => 1, 'name' => 'John', 'surname' => 'Doe', 'retired' => 1])
             ->insert();
-        $this->q($this->c, 'employee')
+        $this->q('employee')
             ->set(['id' => 2, 'name' => 'Jane', 'surname' => 'Doe', 'retired' => 0])
             ->insert();
         $this->assertEquals(
             [['id' => 1, 'name' => 'John'], ['id' => 2, 'name' => 'Jane']],
-            $this->q($this->c, 'employee')->field('id,name')->order('id')->get()
+            $this->q('employee')->field('id,name')->order('id')->get()
         );
         $this->assertEquals(
             [['id' => 1, 'name' => 'John'], ['id' => 2, 'name' => 'Jane']],
-            $this->q($this->c, 'employee')->field('id,name')->order('id')->select()->fetchAll()
+            $this->q('employee')->field('id,name')->order('id')->select()->fetchAll()
         );
 
         // update
-        $this->q($this->c, 'employee')
+        $this->q('employee')
             ->where('name', 'John')
             ->set('name', 'Johnny')
             ->update();
         $this->assertEquals(
             [['id' => 1, 'name' => 'Johnny'], ['id' => 2, 'name' => 'Jane']],
-            $this->q($this->c, 'employee')->field('id,name')->order('id')->get()
+            $this->q('employee')->field('id,name')->order('id')->get()
         );
 
         // replace
         if ('pgsql' !== $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
-            $this->q($this->c, 'employee')
+            $this->q('employee')
                 ->set(['id' => 1, 'name' => 'Peter', 'surname' => 'Doe', 'retired' => 1])
                 ->replace();
         } else {
-            $this->q($this->c, 'employee')
+            $this->q('employee')
                 ->set(['name' => 'Peter', 'surname' => 'Doe', 'retired' => 1])
                 ->where('id', 1)
                 ->update();
@@ -247,7 +220,7 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
         // not [Peter, Jane] as in MySQL, which in theory does the same thing,
         // but returns [Peter, Jane] - in original order.
         // That's why we add usort here.
-        $data = $this->q($this->c, 'employee')->field('id,name')->get();
+        $data = $this->q('employee')->field('id,name')->get();
         usort($data, function ($a, $b) {
             return $a['id'] - $b['id'];
         });
@@ -257,12 +230,12 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
         );
 
         // delete
-        $this->q($this->c, 'employee')
+        $this->q('employee')
             ->where('retired', 1)
             ->delete();
         $this->assertEquals(
             [['id' => 2, 'name' => 'Jane']],
-            $this->q($this->c, 'employee')->field('id,name')->get()
+            $this->q('employee')->field('id,name')->get()
         );
     }
 
@@ -272,12 +245,7 @@ class SelectTest extends \PHPUnit_Extensions_Database_TestCase
     public function testEmptyGetOne()
     {
         // truncate table
-        $this->q($this->c, 'employee')->truncate();
-        $this->q($this->c, 'employee')->field('name')->getOne();
-    }
-
-    public function testConnection()
-    {
-
+        $this->q('employee')->truncate();
+        $this->q('employee')->field('name')->getOne();
     }
 }


### PR DESCRIPTION
Connection::connect() can take an instance of PDO instead of a dsn. 
But when passing a PDO-instance, it would assume it to be to a mysql database. This could fail, now that other databases are also supported. See #134 

This will fix it, see what kind of database the PDO is connected to, and setup Query- and Expression-classes accordingly.

In future version, when a BC-break can be made, support for passing a PDO to connect() should probably be dropped...