### PR TITLE
Remove restriction for custom ordering keyword

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -1159,12 +1159,8 @@ class Query extends Expression
             $desc = $desc ? 'desc' : '';
         } elseif (strtolower($desc) === 'asc') {
             $desc = '';
-        } elseif ($desc && strtolower($desc) != 'desc') {
-            throw new Exception([
-                'Incorrect ordering keyword',
-                'order by' => $order,
-                'desc'     => $desc,
-            ]);
+        } else {
+            // allows custom order like "order by name desc nulls last" for Oracle
         }
 
         $this->args['order'][] = [$order, $desc];

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1066,6 +1066,15 @@ class QueryTest extends \atk4\core\PHPUnit_AgileTestCase
             'order by "* desc {}"',
             $this->q('[order]')->order($this->q()->escape('* desc {}'))->render()
         );
+        // custom sort order
+        $this->assertEquals(
+            'order by "name" desc nulls last',
+            $this->q('[order]')->order('name', 'desc nulls last')->render()
+        );
+        $this->assertEquals(
+            'order by "name" nulls last',
+            $this->q('[order]')->order('name', 'nulls last')->render()
+        );
     }
 
     /**
@@ -1077,17 +1086,6 @@ class QueryTest extends \atk4\core\PHPUnit_AgileTestCase
     public function testOrderException1()
     {
         $this->q('[order]')->order(['name', 'surname'], 'desc');
-    }
-
-    /**
-     * Incorrect ordering keyword.
-     *
-     * @covers ::order
-     * @expectedException Exception
-     */
-    public function testOrderException2()
-    {
-        $this->q('[order]')->order('name', 'random_order');
     }
 
     /**


### PR DESCRIPTION
Remove restriction for custom ordering keyword because some DB engines like Oracle can have order statement like this: `ORDER BY name DESC NULLS LAST`.