### PR TITLE
re-add tests (Random) which I renamed

### DIFF
--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -737,6 +737,11 @@ Other Methods
     Use this instead of `new Query()` if you want to automatically bind query
     to the same connection as the parent.
 
+.. php:method:: expr($template, $args)
+
+    Method very similar to :php:method:`Connection::expr` but will return a
+    corresponding Expression class for this query.
+
 .. php:method:: option($option, $mode)
 
     Use this to set additional options for particular query mode.

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace atk4\dsql;
+
+use atk4\dsql\Query;
+use atk4\dsql\Query_MySQL;
+
+/**
+ * @coversDefaultClass \atk4\dsql\Query
+ */
+class RandomTests extends \atk4\core\PHPUnit_AgileTestCase
+{
+    public function q()
+    {
+        $args = func_get_args();
+        switch (count($args)) {
+            case 1:
+                return new Query($args[0]);
+            case 2:
+                return new Query($args[0], $args[1]);
+        }
+
+        return new Query();
+    }
+
+    public function testMiscInsert()
+    {
+        return $this->markTestIncomplete(
+          'This test has not been implemented yet.'
+        );
+        $data = [
+            'id'                    => null,
+            'system_id'             => '3576',
+            'system'                => null,
+            'created_dts'           => 123,
+            'contractor_from'       => null,
+            'contractor_to'         => null,
+            'vat_rate_id'           => null,
+            'currency_id'           => null,
+            'vat_period_id'         => null,
+            'journal_spec_id'       => '147735',
+            'job_id'                => '9341',
+            'nominal_id'            => null,
+            'root_nominal_code'     => null,
+            'doc_type'              => null,
+            'is_cn'                 => 'N',
+            'doc_date'              => null,
+            'ref_no'                => '940 testingqq11111',
+            'po_ref'                => null,
+            'total_gross'           => '100.00',
+            'total_net'             => null,
+            'total_vat'             => null,
+            'exchange_rate'         => null,
+            'note'                  => null,
+            'archive'               => 'N',
+            'fx_document_id'        => null,
+            'exchanged_total_net'   => null,
+            'exchanged_total_gross' => null,
+            'exchanged_total_vat'   => null,
+            'exchanged_total_a'     => null,
+            'exchanged_total_b'     => null,
+        ];
+        $q = $this->q();
+        $q->mode('insert');
+        foreach ($data as $key => $val) {
+            $q->set($data);
+        }
+        $this->assertEquals("insert into  (`id`,`system_id`,`system`,`created_dts`,`contractor_from`,`contractor_to`,`vat_rate_id`,`currency_id`,`vat_period_id`,`journal_spec_id`,`job_id`,`nominal_id`,`root_nominal_code`,`doc_type`,`is_cn`,`doc_date`,`ref_no`,`po_ref`,`total_gross`,`total_net`,`total_vat`,`exchange_rate`,`note`,`archive`,`fx_document_id`,`exchanged_total_net`,`exchanged_total_gross`,`exchanged_total_vat`,`exchanged_total_a`,`exchanged_total_b`) values (NULL,'3576',NULL,123,NULL,NULL,NULL,NULL,NULL,'147735','9341',NULL,NULL,NULL,'N',NULL,'940 testingqq11111',NULL,'100.00',NULL,NULL,NULL,NULL,'N',NULL,NULL,NULL,NULL,NULL,NULL) [:ad, :ac, :ab, :aa, :z, :y, :x, :w, :v, :u, :t, :s, :r, :q, :p, :o, :n, :m, :l, :k, :j, :i, :h, :g, :f, :e, :d, :c, :b, :a]", $q->getDebugQuery());
+    }
+
+    /**
+     * confirms that group concat works for all the SQL vendors we support
+     */
+    function _groupConcatTest($q, $query)
+    {
+        $q->table('people');
+        $q->group('age');
+
+        $q->field('age');
+        $q->field($q->groupConcat('name', ','));
+
+        $q->groupConcat('name', ',');
+
+
+        $this->assertEquals($query, $q->render());
+    }
+
+    function testGroupConcat()
+    {
+        $this->_groupConcatTest(
+            new Query_MySQL(),
+            'select `age`,group_concat(`name` separator :a) from `people` group by `age`'
+        );
+
+        $this->_groupConcatTest(
+            new Query_SQLite(),
+            'select "age",group_concat("name", :a) from "people" group by "age"'
+        );
+
+        $this->_groupConcatTest(
+            new Query_PgSQL(),
+            'select "age",string_agg("name", :a) from "people" group by "age"'
+        );
+
+        $this->_groupConcatTest(
+            new Query_Oracle(),
+            'select "age",listagg("name", :a) from "people" group by "age"'
+        );
+    }
+}

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -2,13 +2,10 @@
 
 namespace atk4\dsql;
 
-use atk4\dsql\Query;
-use atk4\dsql\Query_MySQL;
-
 /**
  * @coversDefaultClass \atk4\dsql\Query
  */
-class RandomTests extends \atk4\core\PHPUnit_AgileTestCase
+class RandomTest extends \atk4\core\PHPUnit_AgileTestCase
 {
     public function q()
     {
@@ -69,9 +66,9 @@ class RandomTests extends \atk4\core\PHPUnit_AgileTestCase
     }
 
     /**
-     * confirms that group concat works for all the SQL vendors we support
+     * confirms that group concat works for all the SQL vendors we support.
      */
-    function _groupConcatTest($q, $query)
+    public function _groupConcatTest($q, $query)
     {
         $q->table('people');
         $q->group('age');
@@ -81,11 +78,10 @@ class RandomTests extends \atk4\core\PHPUnit_AgileTestCase
 
         $q->groupConcat('name', ',');
 
-
         $this->assertEquals($query, $q->render());
     }
 
-    function testGroupConcat()
+    public function testGroupConcat()
     {
         $this->_groupConcatTest(
             new Query_MySQL(),


### PR DESCRIPTION
When merging https://github.com/atk4/dsql/pull/149, I forgot to re-add the test-file I renamed (RandomTest.php), so we sacrificed 0.64% of test coverage.

Now this should be back.