### PR TITLE
WITH implementation

### DIFF
--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -599,6 +599,57 @@ For a more complex join conditions, you can pass second argument as expression::
     $q->join('address a', new Expression('a.name like u.pattern'));
 
 
+Use WITH cursors
+---------------------------
+
+.. php:method:: with(Query $cursor, string $alias, ?array $fields = null, bool $recursive = false)
+
+    If you want to add `WITH` cursor statement in your SQL, then use this method.
+    First parameter defines sub-query to use. Second parameter defines alias of this cursor.
+    By using third, optional argument you can set aliases for columns in cursor.
+    And finally forth, optional argument set if cursors will be recursive or not.
+
+    You can add more than one cursor in your query.
+
+    Did you know: you can use these cursors when joining your query to other tables. Just join cursor instead.
+    
+.. php:method:: withRecursive(Query $cursor, string $alias, ?array $fields = null)
+
+    Same as :php:meth:`with()`, but always sets it as recursive.
+    
+    Keep in mind that if any of cursors added in your query will be recursive, then all cursors will
+    be set recursive. That's how SQL want it to be.
+
+    Example::
+
+    $quotes = $q->table('quotes')
+        ->field('emp_id')
+        ->field($q->expr('sum([])', ['total_net']))
+        ->group('emp_id');
+    $invoices = $q()->table('invoices')
+        ->field('emp_id')
+        ->field($q->expr('sum([])', ['total_net']))
+        ->group('emp_id');
+    $employees = $q
+        ->with($quotes, 'q', ['emp','quoted'])
+        ->with($invoices, 'i', ['emp','invoiced'])
+        ->table('employees')
+        ->join('q.emp')
+        ->join('i.emp')
+        ->field(['name', 'salary', 'q.quoted', 'i.invoiced']);
+
+    This generates SQL below:
+
+.. code-block:: sql
+
+    with
+        `q` (`emp`,`quoted`) as (select `emp_id`,sum(`total_net`) from `quotes` group by `emp_id`),
+        `i` (`emp`,`invoiced`) as (select `emp_id`,sum(`total_net`) from `invoices` group by `emp_id`)
+    select `name`,`salary`,`q`.`quoted`,`i`.`invoiced`
+    from `employees`
+        left join `q` on `q`.`emp` = `employees`.`id`
+        left join `i` on `i`.`emp` = `employees`.`id`
+
 Limiting result-set
 -------------------
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -402,7 +402,7 @@ class Query extends Expression
             $s = $this->_escape($alias).' ';
 
             // set cursor fields
-            if ($fields) {
+            if ($fields !== null) {
                 $s .= '('.implode(',', array_map([$this, '_escape'], $fields)).') ';
             }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -354,29 +354,28 @@ class Query extends Expression
      *
      * @return $this
      */
-    public function with(Query $cursor, string $alias, ?array $fields = null, bool $recursive = false)
+    public function with(self $cursor, string $alias, ?array $fields = null, bool $recursive = false)
     {
         // save cursor in args
         $this->_set_args('with', $alias, [
-            'cursor' => $cursor,
-            'fields' => $fields,
+            'cursor'    => $cursor,
+            'fields'    => $fields,
             'recursive' => $recursive,
         ]);
 
-
         return $this;
     }
-    
+
     /**
      * Recursive WITH query.
      *
-     * @param Query|array $cursor    Specifies cursor query or array [alias=>query] for adding multiple
-     * @param string      $alias     Specify alias for this cursor
-     * @param array  $fields    Optional array of field names used in cursor
+     * @param Query|array $cursor Specifies cursor query or array [alias=>query] for adding multiple
+     * @param string      $alias  Specify alias for this cursor
+     * @param array       $fields Optional array of field names used in cursor
      *
      * @return $this
      */
-    public function withRecursive(Query $cursor, string $alias, ?array $fields = null)
+    public function withRecursive(self $cursor, string $alias, ?array $fields = null)
     {
         return $this->with($cursor, $alias, $fields, true);
     }
@@ -391,7 +390,7 @@ class Query extends Expression
     {
         // will be joined for output
         $ret = [];
-        
+
         if (empty($this->args['with'])) {
             return '';
         }
@@ -400,15 +399,15 @@ class Query extends Expression
         $isRecursive = false;
         foreach ($this->args['with'] as $alias => ['cursor'=>$cursor, 'fields'=>$fields, 'recursive'=>$recursive]) {
             // cursor alias cannot be expression, so simply escape it
-            $s = $this->_escape($alias) . ' ';
-            
+            $s = $this->_escape($alias).' ';
+
             // set cursor fields
             if ($fields) {
-                $s .= '(' . implode(',', array_map([$this, '_escape'], $fields)) . ') ';
+                $s .= '('.implode(',', array_map([$this, '_escape'], $fields)).') ';
             }
 
             // will parameterize the value and escape if necessary
-            $s .= 'as ' . $this->_consume($cursor, 'soft-escape');
+            $s .= 'as '.$this->_consume($cursor, 'soft-escape');
 
             // is at least one recursive ?
             $isRecursive = $isRecursive || $recursive;
@@ -416,9 +415,8 @@ class Query extends Expression
             $ret[] = $s;
         }
 
-        return 'with ' . ($isRecursive ? 'recursive ' : '') . implode(',', $ret) . ' ';
+        return 'with '.($isRecursive ? 'recursive ' : '').implode(',', $ret).' ';
     }
-
 
     /// }}}
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -36,7 +36,7 @@ class Query extends Expression
      *
      * @var string
      */
-    protected $template_select = 'select[option] [field] [from] [table][join][where][group][having][order][limit]';
+    protected $template_select = '[with]select[option] [field] [from] [table][join][where][group][having][order][limit]';
 
     /**
      * INSERT template.
@@ -57,14 +57,14 @@ class Query extends Expression
      *
      * @var string
      */
-    protected $template_delete = 'delete [from] [table_noalias][where][having]';
+    protected $template_delete = '[with]delete [from] [table_noalias][where][having]';
 
     /**
      * UPDATE template.
      *
      * @var string
      */
-    protected $template_update = 'update [table_noalias] set [set] [where]';
+    protected $template_update = '[with]update [table_noalias] set [set] [where]';
 
     /**
      * TRUNCATE template.
@@ -136,10 +136,7 @@ class Query extends Expression
             }
 
             foreach ($field as $alias => $f) {
-                if (is_numeric($alias)) {
-                    $alias = null;
-                }
-                $this->field($f, $alias);
+                $this->field($f, is_numeric($alias) ? null : $alias);
             }
 
             return $this;
@@ -342,6 +339,86 @@ class Query extends Expression
     {
         return empty($this->args['table']) ? '' : 'from';
     }
+
+    /// }}}
+
+    // {{{ with()
+
+    /**
+     * Specify WITH query to be used.
+     *
+     * @param Query  $cursor    Specifies cursor query or array [alias=>query] for adding multiple
+     * @param string $alias     Specify alias for this cursor
+     * @param array  $fields    Optional array of field names used in cursor
+     * @param bool   $recursive Is it recursive?
+     *
+     * @return $this
+     */
+    public function with(Query $cursor, string $alias, ?array $fields = null, bool $recursive = false)
+    {
+        // save cursor in args
+        $this->_set_args('with', $alias, [
+            'cursor' => $cursor,
+            'fields' => $fields,
+            'recursive' => $recursive,
+        ]);
+
+
+        return $this;
+    }
+    
+    /**
+     * Recursive WITH query.
+     *
+     * @param Query|array $cursor    Specifies cursor query or array [alias=>query] for adding multiple
+     * @param string      $alias     Specify alias for this cursor
+     * @param array  $fields    Optional array of field names used in cursor
+     *
+     * @return $this
+     */
+    public function withRecursive(Query $cursor, string $alias, ?array $fields = null)
+    {
+        return $this->with($cursor, $alias, $fields, true);
+    }
+
+    /**
+     * Renders part of the template: [with]
+     * Do not call directly.
+     *
+     * @return string Parsed template chunk
+     */
+    protected function _render_with()
+    {
+        // will be joined for output
+        $ret = [];
+        
+        if (empty($this->args['with'])) {
+            return '';
+        }
+
+        // process each defined cursor
+        $isRecursive = false;
+        foreach ($this->args['with'] as $alias => ['cursor'=>$cursor, 'fields'=>$fields, 'recursive'=>$recursive]) {
+            // cursor alias cannot be expression, so simply escape it
+            $s = $this->_escape($alias) . ' ';
+            
+            // set cursor fields
+            if ($fields) {
+                $s .= '(' . implode(',', array_map([$this, '_escape'], $fields)) . ') ';
+            }
+
+            // will parameterize the value and escape if necessary
+            $s .= 'as ' . $this->_consume($cursor, 'soft-escape');
+
+            // is at least one recursive ?
+            $isRecursive = $isRecursive || $recursive;
+
+            $ret[] = $s;
+        }
+
+        return 'with ' . ($isRecursive ? 'recursive ' : '') . implode(',', $ret) . ' ';
+    }
+
 
     /// }}}
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1716,7 +1716,7 @@ class QueryTest extends \atk4\core\PHPUnit_AgileTestCase
                 ->render()
         );
     }
-    
+
     /**
      * Test WITH.
      */
@@ -1731,39 +1731,34 @@ class QueryTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $q2 = $this->q()
             ->with($q1, 'q1', null, true)
-            ->table('q1')
-            ;
+            ->table('q1');
         $this->assertEquals('with recursive "q1" as (select "salary" from "salaries") select * from "q1"', $q2->render());
 
         $q2 = $this->q()
-            ->with($q1, 'q11', ['foo','qwe"ry'])
-            ->with($q1, 'q12', ['bar','baz'], true) // this one is recursive
+            ->with($q1, 'q11', ['foo', 'qwe"ry'])
+            ->with($q1, 'q12', ['bar', 'baz'], true) // this one is recursive
             ->table('q11')
-            ->table('q12')
-            ;
+            ->table('q12');
         $this->assertEquals('with recursive "q11" ("foo","qwe""ry") as (select "salary" from "salaries"),"q12" ("bar","baz") as (select "salary" from "salaries") select * from "q11","q12"', $q2->render());
-        
+
         // now test some more useful reql life query
         $quotes = $this->q()
             ->table('quotes')
             ->field('emp_id')
             ->field($this->q()->expr('sum([])', ['total_net']))
-            ->group('emp_id')
-            ;
+            ->group('emp_id');
         $invoices = $this->q()
             ->table('invoices')
             ->field('emp_id')
             ->field($this->q()->expr('sum([])', ['total_net']))
-            ->group('emp_id')
-            ;
+            ->group('emp_id');
         $q = $this->q()
-            ->with($quotes, 'q', ['emp','quoted'])
-            ->with($invoices, 'i', ['emp','invoiced'])
+            ->with($quotes, 'q', ['emp', 'quoted'])
+            ->with($invoices, 'i', ['emp', 'invoiced'])
             ->table('employees')
             ->join('q.emp')
             ->join('i.emp')
-            ->field(['name', 'salary', 'q.quoted', 'i.invoiced'])
-            ;
+            ->field(['name', 'salary', 'q.quoted', 'i.invoiced']);
         $this->assertEquals(
             'with '.
                 '"q" ("emp","quoted") as (select "emp_id",sum(:a) from "quotes" group by "emp_id"),'.
@@ -1772,6 +1767,7 @@ class QueryTest extends \atk4\core\PHPUnit_AgileTestCase
             'from "employees" '.
                 'left join "q" on "q"."emp" = "employees"."id" '.
                 'left join "i" on "i"."emp" = "employees"."id"',
-            $q->render());
+            $q->render()
+        );
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1716,4 +1716,62 @@ class QueryTest extends \atk4\core\PHPUnit_AgileTestCase
                 ->render()
         );
     }
+    
+    /**
+     * Test WITH.
+     */
+    public function testWith()
+    {
+        $q1 = $this->q()->table('salaries')->field('salary');
+
+        $q2 = $this->q()
+            ->with($q1, 'q1')
+            ->table('q1');
+        $this->assertEquals('with "q1" as (select "salary" from "salaries") select * from "q1"', $q2->render());
+
+        $q2 = $this->q()
+            ->with($q1, 'q1', null, true)
+            ->table('q1')
+            ;
+        $this->assertEquals('with recursive "q1" as (select "salary" from "salaries") select * from "q1"', $q2->render());
+
+        $q2 = $this->q()
+            ->with($q1, 'q11', ['foo','qwe"ry'])
+            ->with($q1, 'q12', ['bar','baz'], true) // this one is recursive
+            ->table('q11')
+            ->table('q12')
+            ;
+        $this->assertEquals('with recursive "q11" ("foo","qwe""ry") as (select "salary" from "salaries"),"q12" ("bar","baz") as (select "salary" from "salaries") select * from "q11","q12"', $q2->render());
+        
+        // now test some more useful reql life query
+        $quotes = $this->q()
+            ->table('quotes')
+            ->field('emp_id')
+            ->field($this->q()->expr('sum([])', ['total_net']))
+            ->group('emp_id')
+            ;
+        $invoices = $this->q()
+            ->table('invoices')
+            ->field('emp_id')
+            ->field($this->q()->expr('sum([])', ['total_net']))
+            ->group('emp_id')
+            ;
+        $q = $this->q()
+            ->with($quotes, 'q', ['emp','quoted'])
+            ->with($invoices, 'i', ['emp','invoiced'])
+            ->table('employees')
+            ->join('q.emp')
+            ->join('i.emp')
+            ->field(['name', 'salary', 'q.quoted', 'i.invoiced'])
+            ;
+        $this->assertEquals(
+            'with '.
+                '"q" ("emp","quoted") as (select "emp_id",sum(:a) from "quotes" group by "emp_id"),'.
+                '"i" ("emp","invoiced") as (select "emp_id",sum(:b) from "invoices" group by "emp_id") '.
+            'select "name","salary","q"."quoted","i"."invoiced" '.
+            'from "employees" '.
+                'left join "q" on "q"."emp" = "employees"."id" '.
+                'left join "i" on "i"."emp" = "employees"."id"',
+            $q->render());
+    }
 }


### PR DESCRIPTION
This PR implements `WITH` statement.
fix #117 

```
$quotes = $q->table('quotes')
    ->field('emp_id')
    ->field($q->expr('sum([])', ['total_net']))
    ->group('emp_id');
$invoices = $q()->table('invoices')
    ->field('emp_id')
    ->field($q->expr('sum([])', ['total_net']))
    ->group('emp_id');
$employees = $q
    ->with($quotes, 'q', ['emp','quoted'])
    ->with($invoices, 'i', ['emp','invoiced'])
    ->table('employees')
    ->join('q.emp')
    ->join('i.emp')
    ->field(['name', 'salary', 'q.quoted', 'i.invoiced']);
```

This generates SQL below:
```
with
    `q` (`emp`,`quoted`) as (select `emp_id`,sum(`total_net`) from `quotes` group by `emp_id`),
    `i` (`emp`,`invoiced`) as (select `emp_id`,sum(`total_net`) from `invoices` group by `emp_id`)
select `name`,`salary`,`q`.`quoted`,`i`.`invoiced`
from `employees`
    left join `q` on `q`.`emp` = `employees`.`id`
    left join `i` on `i`.`emp` = `employees`.`id`
```
