### PR TITLE
Improve DSQL exception for SQL

### DIFF
--- a/src/Exception_SQL.php
+++ b/src/Exception_SQL.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace atk4\dsql;
+
+class Exception_SQL extends Exception
+{
+    public function getErrorMessage(): string
+    {
+        return $this->getParams('error');
+    }
+
+    public function getDebugQuery(): string
+    {
+        return $this->getParams('query');
+    }
+}

--- a/src/ExecuteException.php
+++ b/src/ExecuteException.php
@@ -2,7 +2,7 @@
 
 namespace atk4\dsql;
 
-class Exception_SQL extends Exception
+class ExecuteException extends Exception
 {
     public function getErrorMessage(): string
     {

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -615,12 +615,19 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
             try {
                 $statement->execute();
             } catch (\Exception $e) {
-                $new = new Exception([
-                    'DSQL got Exception when executing this query',
-                    'error' => $e->getMessage(),
-                    'query' => $this->getDebugQuery(),
-                ]);
-                $new->by_exception = $e;
+                $msg = 'DSQL got Exception when executing this query';
+                if ($e instanceof \PDOException) {
+                    $new = new Exception_SQL([
+                        $msg,
+                        'error' => $e->errorInfo[2],
+                        'query' => $this->getDebugQuery(),
+                    ], $e->errorInfo[1]);
+                } else { // code should never get here with PDO driver
+                    $new = new Exception_SQL([
+                        $msg,
+                        'query' => $this->getDebugQuery(),
+                    ], null, $e);
+                }
 
                 throw $new;
             }

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -614,20 +614,12 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
 
             try {
                 $statement->execute();
-            } catch (\Exception $e) {
-                $msg = 'DSQL got Exception when executing this query';
-                if ($e instanceof \PDOException) {
-                    $new = new Exception_SQL([
-                        $msg,
-                        'error' => $e->errorInfo[2],
-                        'query' => $this->getDebugQuery(),
-                    ], $e->errorInfo[1]);
-                } else { // code should never get here with PDO driver
-                    $new = new Exception_SQL([
-                        $msg,
-                        'query' => $this->getDebugQuery(),
-                    ], null, $e);
-                }
+            } catch (\PDOException $e) {
+                $new = new ExecuteException([
+                    'DSQL got Exception when executing this query',
+                    'error' => $e->errorInfo[2],
+                    'query' => $this->getDebugQuery(),
+                ], $e->errorInfo[1]);
 
                 throw $new;
             }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -52,7 +52,7 @@ class ExceptionTest extends \atk4\core\PHPUnit_AgileTestCase
             );
         }
     }
-    
+
     public function testNonexistantFieldException()
     {
         $c = Connection::connect('sqlite::memory:');

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -2,13 +2,20 @@
 
 namespace atk4\dsql\tests;
 
+use atk4\dsql\Connection;
 use atk4\dsql\Expression;
+use atk4\dsql\Query;
 
 /**
  * @coversDefaultClass \atk4\dsql\Exception
  */
 class ExceptionTest extends \atk4\core\PHPUnit_AgileTestCase
 {
+    public function q()
+    {
+        return new Query(...func_get_args());
+    }
+
     /**
      * Test constructor.
      *
@@ -44,5 +51,15 @@ class ExceptionTest extends \atk4\core\PHPUnit_AgileTestCase
                 $e->getParams()['tag']
             );
         }
+    }
+    
+    public function testNonexistantFieldException()
+    {
+        $c = Connection::connect('sqlite::memory:');
+        $q = $c->dsql();
+        $q->table('foo')->field('do_not_exist');
+
+        $this->setExpectedException('atk4\dsql\ExecuteException');
+        $q->execute(); // PDOException: SQLSTATE[HY000]: General error: 1 no such table: foo
     }
 }

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -13,15 +13,7 @@ class ExpressionTest extends \atk4\core\PHPUnit_AgileTestCase
 {
     public function e()
     {
-        $args = func_get_args();
-        switch (count($args)) {
-            case 1:
-                return new Expression($args[0]);
-            case 2:
-                return new Expression($args[0], $args[1]);
-        }
-
-        return new Expression();
+        return new Expression(...func_get_args());
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -17,15 +17,7 @@ class QueryTest extends \atk4\core\PHPUnit_AgileTestCase
 {
     public function q()
     {
-        $args = func_get_args();
-        switch (count($args)) {
-            case 1:
-                return new Query($args[0]);
-            case 2:
-                return new Query($args[0], $args[1]);
-        }
-
-        return new Query();
+        return new Query(...func_get_args());
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -9,15 +9,7 @@ class RandomTest extends \atk4\core\PHPUnit_AgileTestCase
 {
     public function q()
     {
-        $args = func_get_args();
-        switch (count($args)) {
-            case 1:
-                return new Query($args[0]);
-            case 2:
-                return new Query($args[0], $args[1]);
-        }
-
-        return new Query();
+        return new Query(...func_get_args());
     }
 
     public function testMiscInsert()


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2228672/78023393-d9ff7280-7356-11ea-982a-4615155af3be.png)

After:
![image](https://user-images.githubusercontent.com/2228672/78024517-c6eda200-7358-11ea-860a-6f11ae001659.png)


Now the SQL execute exception has it's own class, so it can be better tested and error code/message is now much better accessible.