### PR TITLE
Implemented class mapping

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -648,7 +648,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
      *
      * @return array
      */
-    public function get()
+    public function get(string $classname = 'stdClass')
     {
         $stmt = $this->execute();
 
@@ -656,7 +656,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
             return iterator_to_array($stmt);
         }
 
-        return $stmt->fetchAll();
+        return $stmt->fetchAll(\PDO::FETCH_CLASS, $classname);
     }
 
     /**
@@ -664,9 +664,9 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
      *
      * @return string
      */
-    public function getOne()
+    public function getOne(string $classname = 'stdClass')
     {
-        $data = $this->getRow();
+        $data = $this->getRow($classname);
         if (!$data) {
             throw new Exception([
                 'Unable to fetch single cell of data for getOne from this query',
@@ -684,7 +684,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
      *
      * @return array
      */
-    public function getRow()
+    public function getRow(string $classname = 'stdClass')
     {
         $stmt = $this->execute();
 
@@ -692,7 +692,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
             return $stmt->current();
         }
 
-        return $stmt->fetch();
+        return $stmt->fetchObject($classname);
     }
 
     // }}}

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -648,7 +648,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
      *
      * @return array
      */
-    public function get(string $classname = 'stdClass')
+    public function get(string $classname = 'stdClass', $returnObject = false)
     {
         $stmt = $this->execute();
 
@@ -656,7 +656,11 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
             return iterator_to_array($stmt);
         }
 
-        return $stmt->fetchAll(\PDO::FETCH_CLASS, $classname);
+        if ($returnObject) {
+            return $stmt->fetchAll(\PDO::FETCH_CLASS, $classname);
+        }
+
+        return $stmt->fetchAll();
     }
 
     /**
@@ -664,9 +668,9 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
      *
      * @return string
      */
-    public function getOne(string $classname = 'stdClass')
+    public function getOne(string $classname = 'stdClass', $returnObject = false)
     {
-        $data = $this->getRow($classname);
+        $data = $this->getRow($classname, $returnObject);
         if (!$data) {
             throw new Exception([
                 'Unable to fetch single cell of data for getOne from this query',
@@ -684,15 +688,17 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
      *
      * @return array
      */
-    public function getRow(string $classname = 'stdClass')
+    public function getRow(string $classname = 'stdClass', $returnObject = false)
     {
         $stmt = $this->execute();
 
         if ($stmt instanceof \Generator) {
             return $stmt->current();
         }
-
-        return $stmt->fetchObject($classname);
+        if ($returnObject) {
+            return $stmt->fetchObject($classname);
+        }
+        return $stmt->fetch();
     }
 
     // }}}

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -13,9 +13,9 @@ interface ResultSet
 {
     //public function where($field, $value);
     //public function count();
-    public function get();
+    public function get(string $classname);
 
-    public function getRow();
+    public function getRow(string $classname);
 
-    public function getOne();
+    public function getOne(string $classname);
 }

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -13,9 +13,9 @@ interface ResultSet
 {
     //public function where($field, $value);
     //public function count();
-    public function get(string $classname);
+    public function get(string $classname, bool $returnObject);
 
-    public function getRow(string $classname);
+    public function getRow(string $classname, bool $returnObject);
 
-    public function getOne(string $classname);
+    public function getOne(string $classname, bool $returnObject);
 }


### PR DESCRIPTION
Hello,

I implemented `PDO::FETCH_CLASS` in a non-breaking, optional way

Compare with Example #4: https://www.php.net/manual/de/pdostatement.fetchall.php

This effects `get()`, `getOne()` and `getRow()` in `Expression.php`.

Maybe it's of use?

Thanks, Kurt