### PR TITLE
Implement query->allowToWrapInParenthesis property

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -276,7 +276,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         $ret = $sql_code->render();
 
         // Queries should be wrapped in parentheses in most cases
-        if ($sql_code instanceof Query) {
+        if ($sql_code instanceof Query && $sql_code->wrapInParenthesis === true) {
             $ret = '(' . $ret . ')';
         }
 

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -276,7 +276,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         $ret = $sql_code->render();
 
         // Queries should be wrapped in parentheses in most cases
-        if ($sql_code instanceof Query && $sql_code->wrapInParenthesis === true) {
+        if ($sql_code instanceof Query && $sql_code->allowToWrapInParenthesis === true) {
             $ret = '(' . $ret . ')';
         }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -27,6 +27,9 @@ class Query extends Expression
 
     /** @var string Expression classname */
     protected $expression_class = Expression::class;
+    
+    /** @var bool Should we wrap query in parenthesis when rendering? */
+    public $wrapInParenthesis = true;
 
     /**
      * SELECT template.

--- a/src/Query.php
+++ b/src/Query.php
@@ -27,7 +27,7 @@ class Query extends Expression
 
     /** @var string Expression classname */
     protected $expression_class = Expression::class;
-    
+
     /** @var bool Should we wrap query in parenthesis when rendering? */
     public $wrapInParenthesis = true;
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -28,8 +28,8 @@ class Query extends Expression
     /** @var string Expression classname */
     protected $expression_class = Expression::class;
 
-    /** @var bool Should we wrap query in parenthesis when rendering? */
-    public $wrapInParenthesis = true;
+    /** @var bool Do we allow to wrap query in parenthesis when rendering? */
+    public $allowToWrapInParenthesis = true;
 
     /**
      * SELECT template.

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -687,8 +687,8 @@ class QueryTest extends AtkPhpunit\TestCase
         // SQLite do not support (($q1) union ($q2)) syntax. Correct syntax is ($q1 union $q2) without additional braces
         // Other SQL engines are more relaxed, but still these additional braces are not needed for union
         // Let's test how to do that properly
-        $q1->wrapInParenthesis = false;
-        $q2->wrapInParenthesis = false;
+        $q1->allowToWrapInParenthesis = false;
+        $q2->allowToWrapInParenthesis = false;
         $u = new Expression('([] union [])', [$q1, $q2]);
         $this->assertSame(
             '(select "date","amount" "debit",0 "credit" from "sales" union select "date",0 "debit","amount" "credit" from "purchases")',

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -679,7 +679,7 @@ class QueryTest extends AtkPhpunit\TestCase
         $q = $this->q()
             ->field('date,debit,credit')
             ->table($u, 'derrivedTable');
-        $this->assertEquals(
+        $this->assertSame(
             'select "date","debit","credit" from ((select "date","amount" "debit",0 "credit" from "sales") union (select "date",0 "debit","amount" "credit" from "purchases")) "derrivedTable"',
             $q->render()
         );
@@ -699,7 +699,7 @@ class QueryTest extends AtkPhpunit\TestCase
         $q = $this->q()
             ->field('date,debit,credit')
             ->table($u, 'derrivedTable');
-        $this->assertEquals(
+        $this->assertSame(
             'select "date","debit","credit" from (select "date","amount" "debit",0 "credit" from "sales" union select "date",0 "debit","amount" "credit" from "purchases") "derrivedTable"',
             $q->render()
         );


### PR DESCRIPTION
This property is useful in certain cases when query is included as subquery and you do not need to wrap this query in parenthesis.

One example is UNION syntax for SQLite. SQLite will fail with following syntax:
```
SELECT * FROM ((SELECT id FROM a) UNION (SELECT id FROM b)) d
```
Correct syntax in this case is:
```
SELECT * FROM (SELECT id FROM a UNION SELECT id FROM b) d
```

Other SQL engines (MySQL for example) are more relaxed about this and allow these parenthesis, but still they are not required for UNION.
Maybe this property can be useful in some other cases too in future.