### PR TITLE
Fix PSR class/trait/method naming

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -252,7 +252,7 @@ query "LOAD DATA INFILE":
 So to implement our task, you might need a class like this::
 
     use \atk4\dsql\Exception;
-    class Query_MySQL extends \atk4\dsql\Mysql\Query
+    class QueryMysqlCustom extends \atk4\dsql\Mysql\Query
     {
         protected $template_load_data = 'load data local infile [file] into table [table]';
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -9,7 +9,7 @@ namespace atk4\dsql;
  */
 class Connection
 {
-    use \atk4\core\DIContainerTrait;
+    use \atk4\core\DiContainerTrait;
 
     /** @var string Query classname */
     protected $query_class = Query::class;
@@ -58,7 +58,7 @@ class Connection
      *
      * @return array
      */
-    public static function normalizeDSN($dsn, $user = null, $pass = null)
+    public static function normalizeDsn($dsn, $user = null, $pass = null)
     {
         // Try to dissect DSN into parts
         $parts = is_array($dsn) ? $dsn : parse_url($dsn);
@@ -152,13 +152,13 @@ class Connection
         }
 
         // Process DSN string
-        $dsn = static::normalizeDSN($dsn, $user, $password);
+        $dsn = static::normalizeDsn($dsn, $user, $password);
 
         // Create driverType specific connection
         switch ($dsn['driverType']) {
             case 'mysql':
                 $c = new static(array_merge([
-                    'connection' => static::getPDO($dsn),
+                    'connection' => static::getPdo($dsn),
                     'expression_class' => Mysql\Expression::class,
                     'query_class' => Mysql\Query::class,
                     'driverType' => $dsn['driverType'],
@@ -167,7 +167,7 @@ class Connection
                 break;
             case 'sqlite':
                 $c = new static(array_merge([
-                    'connection' => static::getPDO($dsn),
+                    'connection' => static::getPdo($dsn),
                     'query_class' => Sqlite\Query::class,
                     'driverType' => $dsn['driverType'],
                 ], $args));
@@ -175,7 +175,7 @@ class Connection
                 break;
             case 'oci':
                 $c = new Oracle\Connection(array_merge([
-                    'connection' => static::getPDO($dsn),
+                    'connection' => static::getPdo($dsn),
                     'driverType' => $dsn['driverType'],
                 ], $args));
 
@@ -183,14 +183,14 @@ class Connection
             case 'oci12':
                 $dsn['dsn'] = str_replace('oci12:', 'oci:', $dsn['dsn']);
                 $c = new Oracle\Version12\Connection(array_merge([
-                    'connection' => static::getPDO($dsn),
+                    'connection' => static::getPdo($dsn),
                     'driverType' => $dsn['driverType'],
                 ], $args));
 
                 break;
             case 'pgsql':
                 $c = new Postgresql\Connection(array_merge([
-                    'connection' => static::getPDO($dsn),
+                    'connection' => static::getPdo($dsn),
                     'driverType' => $dsn['driverType'],
                 ], $args));
 
@@ -212,7 +212,7 @@ class Connection
             // let PDO handle the rest
             default:
                 $c = new static(array_merge([
-                    'connection' => static::connect(static::getPDO($dsn)),
+                    'connection' => static::connect(static::getPdo($dsn)),
                 ], $args));
         }
 
@@ -224,7 +224,7 @@ class Connection
      *
      * This does not silence PDO errors.
      */
-    protected static function getPDO(array $dsn)
+    protected static function getPdo(array $dsn)
     {
         return new \PDO($dsn['dsn'], $dsn['user'], $dsn['pass'], [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
     }
@@ -406,8 +406,8 @@ class Connection
      *
      * @return mixed
      */
-    public function lastInsertID(string $sequence = null)
+    public function lastInsertId(string $sequence = null)
     {
-        return $sequence === null ? $this->connection()->lastInsertID() : $this->connection()->lastInsertID($sequence);
+        return $sequence === null ? $this->connection()->lastInsertId() : $this->connection()->lastInsertId($sequence);
     }
 }

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -256,7 +256,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
 
         // User may add Expressionable trait to any class, then pass it's objects
         if ($sql_code instanceof Expressionable) {
-            $sql_code = $sql_code->getDSQLExpression($this);
+            $sql_code = $sql_code->getDsqlExpression($this);
         }
 
         if (!$sql_code instanceof self) {

--- a/src/Expressionable.php
+++ b/src/Expressionable.php
@@ -6,5 +6,5 @@ namespace atk4\dsql;
 
 interface Expressionable
 {
-    public function getDSQLExpression($expression);
+    public function getDsqlExpression($expression);
 }

--- a/src/Oracle/Connection.php
+++ b/src/Oracle/Connection.php
@@ -40,13 +40,13 @@ class Connection extends BaseConnection
      *
      * @return mixed
      */
-    public function lastInsertID(string $sequence = null)
+    public function lastInsertId(string $sequence = null)
     {
         if ($sequence) {
             return $this->dsql()->mode('seq_currval')->sequence($sequence)->getOne();
         }
 
         // fallback
-        return parent::lastInsertID($sequence);
+        return parent::lastInsertId($sequence);
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -27,45 +27,45 @@ class ConnectionTest extends AtkPhpunit\TestCase
     /**
      * Test DSN normalize.
      */
-    public function testDSNNormalize()
+    public function testDsnNormalize()
     {
         // standard
-        $dsn = Connection::normalizeDSN('mysql://root:pass@localhost/db');
+        $dsn = Connection::normalizeDsn('mysql://root:pass@localhost/db');
         $this->assertSame(['dsn' => 'mysql:host=localhost;dbname=db', 'user' => 'root', 'pass' => 'pass', 'driverType' => 'mysql', 'rest' => 'host=localhost;dbname=db'], $dsn);
 
-        $dsn = Connection::normalizeDSN('mysql:host=localhost;dbname=db');
+        $dsn = Connection::normalizeDsn('mysql:host=localhost;dbname=db');
         $this->assertSame(['dsn' => 'mysql:host=localhost;dbname=db', 'user' => null, 'pass' => null, 'driverType' => 'mysql', 'rest' => 'host=localhost;dbname=db'], $dsn);
 
-        $dsn = Connection::normalizeDSN('mysql:host=localhost;dbname=db', 'root', 'pass');
+        $dsn = Connection::normalizeDsn('mysql:host=localhost;dbname=db', 'root', 'pass');
         $this->assertSame(['dsn' => 'mysql:host=localhost;dbname=db', 'user' => 'root', 'pass' => 'pass', 'driverType' => 'mysql', 'rest' => 'host=localhost;dbname=db'], $dsn);
 
         // username and password should take precedence
-        $dsn = Connection::normalizeDSN('mysql://root:pass@localhost/db', 'foo', 'bar');
+        $dsn = Connection::normalizeDsn('mysql://root:pass@localhost/db', 'foo', 'bar');
         $this->assertSame(['dsn' => 'mysql:host=localhost;dbname=db', 'user' => 'foo', 'pass' => 'bar', 'driverType' => 'mysql', 'rest' => 'host=localhost;dbname=db'], $dsn);
 
         // more options
-        $dsn = Connection::normalizeDSN('mysql://root:pass@localhost/db;foo=bar');
+        $dsn = Connection::normalizeDsn('mysql://root:pass@localhost/db;foo=bar');
         $this->assertSame(['dsn' => 'mysql:host=localhost;dbname=db;foo=bar', 'user' => 'root', 'pass' => 'pass', 'driverType' => 'mysql', 'rest' => 'host=localhost;dbname=db;foo=bar'], $dsn);
 
         // no password
-        $dsn = Connection::normalizeDSN('mysql://root@localhost/db');
+        $dsn = Connection::normalizeDsn('mysql://root@localhost/db');
         $this->assertSame(['dsn' => 'mysql:host=localhost;dbname=db', 'user' => 'root', 'pass' => null, 'driverType' => 'mysql', 'rest' => 'host=localhost;dbname=db'], $dsn);
-        $dsn = Connection::normalizeDSN('mysql://root:@localhost/db'); // see : after root
+        $dsn = Connection::normalizeDsn('mysql://root:@localhost/db'); // see : after root
         $this->assertSame(['dsn' => 'mysql:host=localhost;dbname=db', 'user' => 'root', 'pass' => null, 'driverType' => 'mysql', 'rest' => 'host=localhost;dbname=db'], $dsn);
 
         // specific DSNs
-        $dsn = Connection::normalizeDSN('stopwatch:sqlite::memory');
+        $dsn = Connection::normalizeDsn('stopwatch:sqlite::memory');
         $this->assertSame(['dsn' => 'stopwatch:sqlite::memory', 'user' => null, 'pass' => null, 'driverType' => 'stopwatch', 'rest' => 'sqlite::memory'], $dsn);
 
-        $dsn = Connection::normalizeDSN('sqlite::memory');
+        $dsn = Connection::normalizeDsn('sqlite::memory');
         $this->assertSame(['dsn' => 'sqlite::memory', 'user' => null, 'pass' => null, 'driverType' => 'sqlite', 'rest' => ':memory'], $dsn); // rest is unusable anyway in this context
 
         // with port number as URL, normalize port to ;port=1234
-        $dsn = Connection::normalizeDSN('mysql://root:pass@localhost:1234/db');
+        $dsn = Connection::normalizeDsn('mysql://root:pass@localhost:1234/db');
         $this->assertSame(['dsn' => 'mysql:host=localhost;port=1234;dbname=db', 'user' => 'root', 'pass' => 'pass', 'driverType' => 'mysql', 'rest' => 'host=localhost;port=1234;dbname=db'], $dsn);
 
         // with port number as DSN, leave port as :port
-        $dsn = Connection::normalizeDSN('mysql:host=localhost:1234;dbname=db');
+        $dsn = Connection::normalizeDsn('mysql:host=localhost:1234;dbname=db');
         $this->assertSame(['dsn' => 'mysql:host=localhost:1234;dbname=db', 'user' => null, 'pass' => null, 'driverType' => 'mysql', 'rest' => 'host=localhost:1234;dbname=db'], $dsn);
     }
 

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -512,7 +512,7 @@ class JsonExpression extends Expression
 }
 class MyField implements Expressionable
 {
-    public function getDSQLExpression($e)
+    public function getDsqlExpression($e)
     {
         return $e->expr('"myfield"');
     }


### PR DESCRIPTION
related with https://github.com/atk4/core/pull/258

updated names:
```
Expressionable::getDSQLExpression()
Connection::lastInsertID()
Connection::normalizeDSN()
```
for 100% BC you can require the renamed classes manually (but if some other updated code required them before use is enough)