### PR TITLE
Fix "is null" for PostgresSQL

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -789,10 +789,10 @@ class Query extends Expression
 
         // special conditions (IS | IS NOT) if value is null
         if ($value === null) {
-            if ($cond === '=') {
-                $cond = 'is';
-            } elseif (in_array($cond, ['!=', '<>', 'not'], true)) {
-                $cond = 'is not';
+            if (in_array($cond, ['=', 'is'], true)) {
+                return $field . ' is null';
+            } elseif (in_array($cond, ['!=', '<>', 'not', 'is not'], true)) {
+                return $field . ' is not null';
             }
         }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -757,12 +757,12 @@ class QueryTest extends AtkPhpunit\TestCase
             $this->q('[where]')->where('db.user.id', 1)->render()
         );
         $this->assertSame(
-            'where "id" is :a',
+            'where "id" is null',
             $this->q('[where]')->where('id', null)->render()
         );
         $this->assertSame(
-            'where "id" is :a',
-            $this->q('[where]')->where('id', null)->render()
+            'where "id" is not null',
+            $this->q('[where]')->where('id', '!=', null)->render()
         );
 
         // three parameters - field, condition, value
@@ -819,7 +819,7 @@ class QueryTest extends AtkPhpunit\TestCase
 
         // more than one where condition - join with AND keyword
         $this->assertSame(
-            'where "a" = :a and "b" is :b',
+            'where "a" = :a and "b" is null',
             $this->q('[where]')->where('a', 1)->where('b', null)->render()
         );
     }
@@ -916,27 +916,27 @@ class QueryTest extends AtkPhpunit\TestCase
 
         // is | is not
         $this->assertSame(
-            'where "id" is :a',
+            'where "id" is null',
             $this->q('[where]')->where('id', 'is', null)->render()
         );
         $this->assertSame(
-            'where "id" is not :a',
+            'where "id" is not null',
             $this->q('[where]')->where('id', 'is not', null)->render()
         );
         $this->assertSame(
-            'where "id" is not :a',
+            'where "id" is not null',
             $this->q('[where]')->where('id', 'not', null)->render()
         );
         $this->assertSame(
-            'where "id" is :a',
+            'where "id" is null',
             $this->q('[where]')->where('id', '=', null)->render()
         );
         $this->assertSame(
-            'where "id" is not :a',
+            'where "id" is not null',
             $this->q('[where]')->where('id', '<>', null)->render()
         );
         $this->assertSame(
-            'where "id" is not :a',
+            'where "id" is not null',
             $this->q('[where]')->where('id', '!=', null)->render()
         );
 
@@ -953,15 +953,15 @@ class QueryTest extends AtkPhpunit\TestCase
         // two parameters - more_than_just_a_field, value
         // is | is not
         $this->assertSame(
-            'where "id" is :a',
+            'where "id" is null',
             $this->q('[where]')->where('id=', null)->render()
         );
         $this->assertSame(
-            'where "id" is not :a',
+            'where "id" is not null',
             $this->q('[where]')->where('id!=', null)->render()
         );
         $this->assertSame(
-            'where "id" is not :a',
+            'where "id" is not null',
             $this->q('[where]')->where('id<>', null)->render()
         );
 


### PR DESCRIPTION
PostgresSQL does parse `expr is null` only (instead of ` expr is $1`, where `$1` represents a bounded variable)