### PR TITLE
Fix MSSQL Expression::execute() for nested calls 

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -500,6 +500,8 @@ class Expression implements \ArrayAccess, \IteratorAggregate
 
             $query = $this->render();
 
+            $statement = null;
+
             try {
                 $statement = $connection->prepare($query);
 

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -500,8 +500,6 @@ class Expression implements \ArrayAccess, \IteratorAggregate
 
             $query = $this->render();
 
-            $statement = null;
-
             try {
                 $statement = $connection->prepare($query);
 

--- a/src/Mssql/ExpressionTrait.php
+++ b/src/Mssql/ExpressionTrait.php
@@ -23,7 +23,7 @@ trait ExpressionTrait
 
     // {{{ MSSQL does not support named parameters, so convert them to numerical inside execute
 
-    private $paramsBackup = [];
+    private $paramsBackup;
     private $fixedRender;
 
     public function execute(object $connection = null)
@@ -47,6 +47,7 @@ trait ExpressionTrait
             return parent::execute($connection);
         } finally {
             $this->params = $this->paramsBackup;
+            $this->paramsBackup = null;
             $this->fixedRender = null;
         }
     }
@@ -62,7 +63,9 @@ trait ExpressionTrait
 
     public function getDebugQuery(): string
     {
-        $this->params = $this->paramsBackup;
+        if ($this->paramsBackup !== null) {
+            $this->params = $this->paramsBackup;
+        }
         $this->fixedRender = null;
 
         return parent::getDebugQuery();

--- a/src/Mssql/ExpressionTrait.php
+++ b/src/Mssql/ExpressionTrait.php
@@ -23,7 +23,7 @@ trait ExpressionTrait
 
     // {{{ MSSQL does not support named parameters, so convert them to numerical inside execute
 
-    private $paramsBackup;
+    private $paramsBackup = [];
     private $fixedRender;
 
     public function execute(object $connection = null)

--- a/src/Mssql/ExpressionTrait.php
+++ b/src/Mssql/ExpressionTrait.php
@@ -23,17 +23,21 @@ trait ExpressionTrait
 
     // {{{ MSSQL does not support named parameters, so convert them to numerical inside execute
 
-    private $paramsBackup;
-    private $fixedRender;
+    private $numQueryParamsBackup;
+    private $numQueryRender;
 
     public function execute(object $connection = null)
     {
-        $this->paramsBackup = $this->params;
+        if ($this->numQueryParamsBackup !== null) {
+            return parent::execute($connection);
+        }
+
+        $this->numQueryParamsBackup = $this->params;
         try {
             $numParams = [];
             $i = 0;
             $j = 0;
-            $this->fixedRender = preg_replace_callback(
+            $this->numQueryRender = preg_replace_callback(
                 '~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K(?:\?|:\w+)~s',
                 function ($matches) use (&$numParams, &$i, &$j) {
                     $numParams[++$i] = $this->params[$matches[0] === '?' ? ++$j : $matches[0]];
@@ -46,16 +50,16 @@ trait ExpressionTrait
 
             return parent::execute($connection);
         } finally {
-            $this->params = $this->paramsBackup;
-            $this->paramsBackup = null;
-            $this->fixedRender = null;
+            $this->params = $this->numQueryParamsBackup;
+            $this->numQueryParamsBackup = null;
+            $this->numQueryRender = null;
         }
     }
 
     public function render()
     {
-        if ($this->fixedRender !== null) {
-            return $this->fixedRender;
+        if ($this->numQueryParamsBackup !== null) {
+            return $this->numQueryRender;
         }
 
         return parent::render();
@@ -63,12 +67,24 @@ trait ExpressionTrait
 
     public function getDebugQuery(): string
     {
-        if ($this->paramsBackup !== null) {
-            $this->params = $this->paramsBackup;
+        if ($this->numQueryParamsBackup === null) {
+            return parent::getDebugQuery();
         }
-        $this->fixedRender = null;
 
-        return parent::getDebugQuery();
+        $paramsBackup = $this->params;
+        $numQueryRenderBackupBackup = $this->numQueryParamsBackup;
+        $numQueryRenderBackup = $this->numQueryRender;
+        try {
+            $this->params = $this->numQueryParamsBackup;
+            $this->numQueryParamsBackup = null;
+            $this->numQueryRender = null;
+
+            return parent::getDebugQuery();
+        } finally {
+            $this->params = $paramsBackup;
+            $this->numQueryParamsBackup = $numQueryRenderBackupBackup;
+            $this->numQueryRender = $numQueryRenderBackup;
+        }
     }
 
     /// }}}


### PR DESCRIPTION
`Expression::$params` must always be array, yet in `atk4\dsql\Mssql\ExpressionTrait::getDebugQuery` it was assigned `paramsBackup` which could be null