### PR TITLE
Remove bound values workaround for LOB datatype

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -538,6 +538,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                 }
 
                 $statement->setFetchMode(\PDO::FETCH_ASSOC);
+                unset($boundValues); gc_collect_cycles();
                 $statement->execute();
             } catch (\PDOException $e) {
                 $new = (new ExecuteException('DSQL got Exception when executing this query', $e->errorInfo[1]))

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -503,7 +503,8 @@ class Expression implements \ArrayAccess, \IteratorAggregate
             try {
                 $statement = $connection->prepare($query);
 
-                // workaround to support LOB data type 1/2, see https://github.com/doctrine/dbal/pull/2434
+                // workaround to support LOB data type 1/2
+                // see https://github.com/doctrine/dbal/pull/2434
                 $boundValues = [];
 
                 foreach ($this->params as $key => $val) {
@@ -526,7 +527,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                             ->addMoreInfo('type', gettype($val));
                     }
 
-                    // workaround to support LOB data type 2/2, see https://github.com/doctrine/dbal/pull/2434
+                    // workaround to support LOB data type 2/2
                     $boundValues[$key] = $val;
                     $bind = $statement->bindParam($key, $boundValues[$key], $type);
                     if ($bind === false) {

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -538,7 +538,6 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                 }
 
                 $statement->setFetchMode(\PDO::FETCH_ASSOC);
-                unset($boundValues); gc_collect_cycles();
                 $statement->execute();
             } catch (\PDOException $e) {
                 $new = (new ExecuteException('DSQL got Exception when executing this query', $e->errorInfo[1]))

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -503,9 +503,6 @@ class Expression implements \ArrayAccess, \IteratorAggregate
             try {
                 $statement = $connection->prepare($query);
 
-                // workaround to support LOB data type 1/3, see https://github.com/doctrine/dbal/pull/2434
-                $statement->boundValues = [];
-
                 foreach ($this->params as $key => $val) {
                     if (is_int($val)) {
                         $type = \PDO::PARAM_INT;
@@ -526,10 +523,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                             ->addMoreInfo('type', gettype($val));
                     }
 
-                    // workaround to support LOB data type 2/3, see https://github.com/doctrine/dbal/pull/2434
-                    $statement->boundValues[$key] = $val;
-                    $bind = $statement->bindParam($key, $statement->boundValues[$key], $type);
-
+                    $bind = $statement->bindParam($key, $val, $type);
                     if (!$bind) {
                         throw (new Exception('Unable to bind parameter'))
                             ->addMoreInfo('param', $key)
@@ -546,9 +540,6 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                     ->addMoreInfo('query', $this->getDebugQuery());
 
                 throw $new;
-            } finally {
-                // workaround to support LOB data type 3/3, see https://github.com/doctrine/dbal/pull/2434
-                unset($statement->{'boundValues'});
             }
 
             return $statement;

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -503,10 +503,6 @@ class Expression implements \ArrayAccess, \IteratorAggregate
             try {
                 $statement = $connection->prepare($query);
 
-                // workaround to support LOB data type 1/2
-                // see https://github.com/doctrine/dbal/pull/2434
-                $boundValues = [];
-
                 foreach ($this->params as $key => $val) {
                     if (is_int($val)) {
                         $type = \PDO::PARAM_INT;
@@ -527,9 +523,9 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                             ->addMoreInfo('type', gettype($val));
                     }
 
-                    // workaround to support LOB data type 2/2
-                    $boundValues[$key] = $val;
-                    $bind = $statement->bindParam($key, $boundValues[$key], $type);
+                    $boundValue = $val;
+                    $bind = $statement->bindParam($key, $boundValue, $type);
+                    unset($boundValue);
                     if ($bind === false) {
                         throw (new Exception('Unable to bind parameter'))
                             ->addMoreInfo('param', $key)

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -523,9 +523,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                             ->addMoreInfo('type', gettype($val));
                     }
 
-                    $boundValue = $val;
-                    $bind = $statement->bindParam($key, $boundValue, $type);
-                    unset($boundValue);
+                    $bind = $statement->bindValue($key, $val, $type);
                     if ($bind === false) {
                         throw (new Exception('Unable to bind parameter'))
                             ->addMoreInfo('param', $key)


### PR DESCRIPTION
see "experiment with unset before execute" commit - for some reasons, plain variable can not be passed, but array element can be passed and this array can be unset even before `PDOStatement::execute()`