### PR TITLE
Do not escape/template in quoted SQL string literals/identifiers

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -381,16 +381,31 @@ class Expression implements \ArrayAccess, \IteratorAggregate
             throw new Exception('Template is not defined for Expression');
         }
 
+        // - [xxx] = param
+        // - {xxx} = escape
+        // - {{xxx}} = escapeSoft
         $res = preg_replace_callback(
-            //     param     |  escape   |  escapeSoft
-            '/\[[a-z0-9_]*\]|{[a-z0-9_]*}|{{[a-z0-9_]*}}/i',
+            <<<'EOF'
+            ~
+             '(?:[^'\\]+|\\.|'')*'\K
+            |"(?:[^"\\]+|\\.|"")*"\K
+            |`(?:[^`\\]+|\\.|``)*`\K
+            |\[\w*\]
+            |\{\w*\}
+            |\{\{\w*\}\}
+            ~xs
+            EOF,
             function ($matches) use (&$nameless_count) {
+                if ($matches[0] === '') {
+                    return '';
+                }
+
                 $identifier = substr($matches[0], 1, -1);
 
-                if ($matches[0][0] === '[') {
+                if (substr($matches[0], 0, 1) === '[') {
                     $escaping = 'param';
-                } elseif ($matches[0][0] === '{') {
-                    if ($matches[0][1] === '{') {
+                } elseif (substr($matches[0], 0, 1) === '{') {
+                    if (substr($matches[0], 1, 1) === '{') {
                         $escaping = 'soft-escape';
                         $identifier = substr($identifier, 1, -1);
                     } else {
@@ -398,7 +413,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                     }
                 }
 
-                // Allow template to contain []
+                // allow template to contain []
                 if ($identifier === '') {
                     $identifier = $nameless_count++;
 

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -386,15 +386,15 @@ class Expression implements \ArrayAccess, \IteratorAggregate
         // - {{xxx}} = escapeSoft
         $res = preg_replace_callback(
             <<<'EOF'
-            ~
-             '(?:[^'\\]+|\\.|'')*'\K
-            |"(?:[^"\\]+|\\.|"")*"\K
-            |`(?:[^`\\]+|\\.|``)*`\K
-            |\[\w*\]
-            |\{\w*\}
-            |\{\{\w*\}\}
-            ~xs
-            EOF,
+                ~
+                 '(?:[^'\\]+|\\.|'')*'\K
+                |"(?:[^"\\]+|\\.|"")*"\K
+                |`(?:[^`\\]+|\\.|``)*`\K
+                |\[\w*\]
+                |\{\w*\}
+                |\{\{\w*\}\}
+                ~xs
+                EOF,
             function ($matches) use (&$nameless_count) {
                 if ($matches[0] === '') {
                     return '';

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -210,9 +210,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
                 '\'\'\'[]\'',
                 '\'[]\'\'\'',
             ] as $testStr) {
-                if ($enclosureChar !== '\'') {
-                    $testStr = str_replace('\'', $enclosureChar, $testStr);
-                }
+                $testStr = str_replace('\'', $enclosureChar, $testStr);
 
                 yield [$testStr, $testStr, []];
 

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -188,6 +188,49 @@ class ExpressionTest extends AtkPhpunit\TestCase
     }
 
     /**
+     * @dataProvider provideNoTemplatingInSqlStringData
+     */
+    public function testNoTemplatingInSqlString(string $expectedStr, string $exprStr, array $exprArgs)
+    {
+        $this->assertSame($expectedStr, $this->e($exprStr, $exprArgs)->render());
+    }
+
+    public function provideNoTemplatingInSqlStringData()
+    {
+        $testStrs = [];
+        foreach (['\'', '"', '`'] as $enclosureChar) {
+            foreach ([
+                '\'[]\'',
+                '\'{}\'',
+                '\'{{}}\'',
+                '\'[a]\'',
+                '\'\\\'[]\'',
+                '\'\\\\[]\'',
+                '\'[\'\']\'',
+                '\'\'\'[]\'',
+                '\'[]\'\'\''
+            ] as $testStr) {
+                if ($enclosureChar !== '\'') {
+                    $testStr = str_replace('\'', $enclosureChar, $testStr);
+                }
+
+                yield [$testStr, $testStr, []];
+
+                $testStrs[] = $testStr;
+            }
+        }
+
+        $fullStr = implode('', $testStrs);
+        yield [$fullStr, $fullStr, []];
+
+        $fullStr = implode(' ', $testStrs);
+        yield [$fullStr, $fullStr, []];
+
+        $fullStr = implode('x', $testStrs);
+        yield [$fullStr, $fullStr, []];
+    }
+
+    /**
      * Test nested parameters.
      *
      * @covers ::__construct

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -208,7 +208,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
                 '\'\\\\[]\'',
                 '\'[\'\']\'',
                 '\'\'\'[]\'',
-                '\'[]\'\'\''
+                '\'[]\'\'\'',
             ] as $testStr) {
                 if ($enclosureChar !== '\'') {
                     $testStr = str_replace('\'', $enclosureChar, $testStr);

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -162,9 +162,9 @@ class ExpressionTest extends AtkPhpunit\TestCase
 
         // numeric argument = Expression
         $this->assertSame(
-            'testing "hello, world"',
+            'hello, world',
             $this->e(
-                'testing "[]"',
+                '[]',
                 [
                     $this->e(
                         '[what], [who]',


### PR DESCRIPTION
fixes https://github.com/atk4/dsql/issues/144

string grammars:
- https://github.com/antlr/grammars-v4/blob/729c0a5ae0a22b3f833a906ba45ae5d394252a08/sql/sqlite/SQLiteLexer.g4#L224
- https://github.com/antlr/grammars-v4/blob/a226f52cbf4e1bec86647a9a9dbabda3db8cbe5b/sql/mysql/Positive-Technologies/MySqlLexer.g4#L1236
- https://github.com/antlr/grammars-v4/blob/04fd2b529eb6b4db4944dc7ba96bbb596eefb155/sql/tsql/TSqlLexer.g4#L839
- https://github.com/antlr/grammars-v4/blob/cbc94950e81ffb62badcaf8e00ab8cabc3e1d3dd/sql/plsql/PlSqlLexer.g4#L2283

identifier grammars:
- https://github.com/antlr/grammars-v4/blob/729c0a5ae0a22b3f833a906ba45ae5d394252a08/sql/sqlite/SQLiteLexer.g4#L213
- https://github.com/antlr/grammars-v4/blob/a226f52cbf4e1bec86647a9a9dbabda3db8cbe5b/sql/mysql/Positive-Technologies/MySqlLexer.g4#L1199
- https://github.com/antlr/grammars-v4/blob/04fd2b529eb6b4db4944dc7ba96bbb596eefb155/sql/tsql/TSqlLexer.g4#L831
- https://github.com/antlr/grammars-v4/blob/cbc94950e81ffb62badcaf8e00ab8cabc3e1d3dd/sql/plsql/PlSqlLexer.g4#L2297

BC break:
yes, but uncommon, only if you use templates like `` '`{{x}}`' `` (escape using templating, ie. `'{x}'`), see one problematic test