### PR TITLE
Drop dangerous Expression::__toString() support

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -127,16 +127,6 @@ class Expression implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Casting to string will execute expression and return getOne() value.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return (string) $this->getOne();
-    }
-
-    /**
      * Whether or not an offset exists.
      *
      * @param string An offset to check for

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -127,6 +127,16 @@ class Expression implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
+     * @deprecated will be removed in v2.5
+     */
+    public function __toString()
+    {
+        'trigger_error'('Method is deprecated. Use $this->getOne() instead', E_USER_DEPRECATED);
+
+        return $this->getOne();
+    }
+
+    /**
      * Whether or not an offset exists.
      *
      * @param string An offset to check for

--- a/tests/WithDb/SelectTest.php
+++ b/tests/WithDb/SelectTest.php
@@ -188,39 +188,6 @@ class SelectTest extends AtkPhpunit\TestCase
         }
     }
 
-    /**
-     * covers atk4\dsql\Expression::__toString, but on PHP 5.5 this hint doesn't work.
-     */
-    public function testCastingToString()
-    {
-        // simple value
-        $this->assertSame(
-            'Williams',
-            (string) $this->q('employee')->field('surname')->where('name', 'Jack')
-        );
-        // table as sub-query
-        $this->assertSame(
-            'Williams',
-            (string) $this->q($this->q('employee'), 'e2')->field('surname')->where('name', 'Jack')
-        );
-        // field as expression
-        $this->assertSame(
-            'Williams',
-            (string) $this->q('employee')->field($this->e('{}', ['surname']))->where('name', 'Jack')
-        );
-        // cast to string multiple times
-        $q = $this->q('employee')->field('surname')->where('name', 'Jack');
-        $this->assertSame(
-            ['Williams', 'Williams'],
-            [(string) $q, (string) $q]
-        );
-        // cast custom Expression to string
-        $this->assertSame(
-            '7',
-            (string) $this->e('select 3+4' . ($this->c->getDatabasePlatform() instanceof OraclePlatform ? ' FROM DUAL' : ''))
-        );
-    }
-
     public function testOtherQueries()
     {
         // truncate table


### PR DESCRIPTION
merge once https://github.com/atk4/data/pull/774 is RTM

imagine using expr like:
```
new Expression($nameExpr . ' as name')
```
:)