### PR TITLE
Forbid bind resource type

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -561,7 +561,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                     } elseif (is_string($val) || is_float($val)) {
                         $type = \PDO::PARAM_STR;
                     } elseif (is_resource($val)) {
-                        $type = \PDO::PARAM_LOB;
+                        throw new Exception('Resource type is not supported, set value as string instead');
                     } else {
                         throw (new Exception('Incorrect param type'))
                             ->addMoreInfo('key', $key)


### PR DESCRIPTION
This PR is not stictly needed, but resource can be easily missused. As results are fetched by string always anyway, I think we should merge this.

In the future, if this will be an issue for anything, we can revert, but I am not aware of any reasonable scenarion except saving too big data which can not fit in memory, which cheaper every day.

Also easier to debug as resource can not often be read twice this impossible to dump before query.

In Oracle when something is passed as resource/stream, it cannot be used in SQL query, see:
```
Caused by
atk4\dsql\ExecuteException: DSQL got Exception when executing this query
  error: 'OCIStmtExecute: ORA-00932: inconsistent datatypes: expected CLOB got BLOB
     (ext\pdo_oci\oci_statement.c:157)'
  query: 'update
      "invoice"
    set
      "addr" = 'test'
    where
      "id" = 1'
```
where `test` string literal was passed as a bounded resource/stream:
![image](https://user-images.githubusercontent.com/2228672/97782554-69416280-1b92-11eb-9dad-b22eee463070.png)
