### PR TITLE
Add support for DBAL 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,15 @@
   },
   "require": {
     "php": ">=7.3.0",
+    "ext-pdo": "*",
     "atk4/core": "dev-develop",
-    "doctrine/dbal": "^2.9.3"
+    "doctrine/dbal": "^2.9.3 || ^3.0"
   },
   "require-release": {
     "php": ">=7.3.0",
+    "ext-pdo": "*",
     "atk4/core": "~2.3.0",
-    "doctrine/dbal": "^2.9.3"
+    "doctrine/dbal": "^2.9.3 || ^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -23,8 +23,8 @@ or query::
 
 When it's time to execute you can specify your PDO manually::
 
-    $stmt = $expr->execute($pdo);
-    foreach($stmt as $row){
+    $rows = $expr->getRows($pdo);
+    foreach($rows as $row) {
         echo json_encode($row)."\n";
     }
 
@@ -33,7 +33,7 @@ With queries you might need to select mode first::
     $stmt = $query->selectMode('delete')->execute($pdo);
 
 The :php:meth:`Expresssion::execute` is a convenient way to prepare query,
-bind all parameters and get PDOStatement, but if you wish to do it manually,
+bind all parameters and get `Doctrine\DBAL\Result`, but if you wish to do it manually,
 see `Manual Query Execution`_.
 
 
@@ -169,9 +169,9 @@ So to implement our task, you might need a class like this::
             $this['file'] = $file;
         }
 
-        public function loadData()
+        public function loadData(): array
         {
-            return $this->mode('load_data')->execute();
+            return $this->mode('load_data')->getRows();
         }
     }
 

--- a/docs/connection.rst
+++ b/docs/connection.rst
@@ -77,7 +77,7 @@ if you connect to vendor that does not use PDO.
     Creates new Expression class and sets :php:attr:`Expression::connection`.
 
     :param Expression  $expr: Expression (or query) to execute
-    :returns: PDOStatement, Iterable object or Generator.
+    :returns: `Doctrine\DBAL\Result`
     
 .. php:method:: registerConnectionClass($connectionClass = null, $connectionType = null)
 

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -191,9 +191,7 @@ Finally, you can pass connection class into :php:meth:`execute` directly.
 
         $stmt = $expr -> execute($pdo_dbh);
 
-    returns `PDOStamement <http://php.net/manual/en/class.pdostatement.php>`_ if
-    you have used `PDO <http://php.net/manual/en/class.pdo.php>`_ class or
-    ResultSet if you have used Connection.
+    returns `Doctrine\DBAL\Result`.
 
 .. todo::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -220,9 +220,6 @@ involved, but once the query is executed, you can start streaming your data::
         echo $employee['first_name']."\n";
     }
 
-In most cases, when iterating you'll have PDOStatement, however this may not
-always be the case, so be cautious. Remember that DQSL can support vendors
-that PDO does not support as well or can use :ref:`proxy`.
-In that case you may end up with other Generator/Iterator but regardless,
+When iterating you'll have `Doctrine\DBAL\Result`. Remember that DQSL can support vendors,
 `$employee` will always contain associative array representing one row of data.
 (See also `Manual Query Execution`_).

--- a/docs/results.rst
+++ b/docs/results.rst
@@ -5,7 +5,7 @@ Results
 When query is executed by :php:class:`Connection` or
 `PDO <http://php.net/manual/en/pdo.query.php>`_, it will return an object that
 can stream results back to you. The PDO class execution produces a
-`PDOStatement <http://php.net/manual/en/class.pdostatement.php>`_ object which
+`Doctrine\DBAL\Result`_ object which
 you can iterate over.
 
 If you are using a custom connection, you then will also need a custom object

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -232,19 +232,25 @@ abstract class Connection
         // https://github.com/doctrine/dbal/pull/3912
         // TODO drop once DBAL 2.x support is dropped
         if (
-            (in_array(get_class($dbalConnection->getDatabasePlatform()), [
+            in_array(get_class($dbalConnection->getDatabasePlatform()), [
                 'Doctrine\DBAL\Platforms\SQLServerPlatform',
                 'Doctrine\DBAL\Platforms\SQLServer2005Platform',
                 'Doctrine\DBAL\Platforms\SQLServer2008Platform',
-            ], true) && !($dbalConnection->getDatabasePlatform() instanceof SQLServer2012Platform))
-            || (in_array(get_class($dbalConnection->getDatabasePlatform()), [
+            ], true) && !($dbalConnection->getDatabasePlatform() instanceof SQLServer2012Platform)
+        ) {
+            \Closure::bind(function () use ($dbalConnection) {
+                $dbalConnection->platform = new SQLServer2012Platform();
+            }, null, DbalConnection::class)();
+        } elseif (
+            in_array(get_class($dbalConnection->getDatabasePlatform()), [
                 'Doctrine\DBAL\Platforms\PostgreSqlPlatform',
                 'Doctrine\DBAL\Platforms\PostgreSQL91Platform',
                 'Doctrine\DBAL\Platforms\PostgreSQL92Platform',
-            ], true) && !($dbalConnection->getDatabasePlatform() instanceof PostgreSQL94Platform))
+            ], true) && !($dbalConnection->getDatabasePlatform() instanceof PostgreSQL94Platform)
         ) {
-            throw (new Exception('Database server version is not supported'))
-                ->addMoreInfo('platform_class', get_class($dbalConnection->getDatabasePlatform()));
+            \Closure::bind(function () use ($dbalConnection) {
+                $dbalConnection->platform = new PostgreSQL94Platform();
+            }, null, DbalConnection::class)();
         }
 
         // Oracle CLOB/BLOB has limited SQL support, see:

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -231,14 +231,20 @@ abstract class Connection
         // make sure that DBAL 2.x platform is always supported in DBAL 3.x, see:
         // https://github.com/doctrine/dbal/pull/3912
         // TODO drop once DBAL 2.x support is dropped
-        $platformInterfaces = class_implements($dbalConnection->getDatabasePlatform());
         if (
-            (in_array('Doctrine\DBAL\Platforms\SQLServerPlatform', $platformInterfaces, true)
-            && !($dbalConnection->getDatabasePlatform() instanceof SQLServer2012Platform))
-            || (in_array('Doctrine\DBAL\Platforms\PostgreSQLPlatform', $platformInterfaces, true)
-            && !($dbalConnection->getDatabasePlatform() instanceof PostgreSQL94Platform))
+            (in_array(get_class($dbalConnection->getDatabasePlatform()), [
+                'Doctrine\DBAL\Platforms\SQLServerPlatform',
+                'Doctrine\DBAL\Platforms\SQLServer2005Platform',
+                'Doctrine\DBAL\Platforms\SQLServer2008Platform',
+            ], true) && !($dbalConnection->getDatabasePlatform() instanceof SQLServer2012Platform))
+            || (in_array(get_class($dbalConnection->getDatabasePlatform()), [
+                'Doctrine\DBAL\Platforms\PostgreSqlPlatform',
+                'Doctrine\DBAL\Platforms\PostgreSQL91Platform',
+                'Doctrine\DBAL\Platforms\PostgreSQL92Platform',
+            ], true) && !($dbalConnection->getDatabasePlatform() instanceof PostgreSQL94Platform))
         ) {
-            throw new Exception('Database server version is not supported.');
+            throw (new Exception('Database server version is not supported'))
+                ->addMoreInfo('platform_class', get_class($dbalConnection->getDatabasePlatform()));
         }
 
         // Oracle CLOB/BLOB has limited SQL support, see:

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -508,7 +508,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
     /**
      * Execute expression.
      *
-     * @param \PDO|Connection $connection
+     * @param DbalConnection|Connection $connection
      *
      * @return \PDOStatement
      */
@@ -518,7 +518,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
             $connection = $this->connection;
         }
 
-        // If it's a PDO connection, we're cool
+        // If it's a DBAL connection, we're cool
         if ($connection instanceof DbalConnection) {
             $query = $this->render();
 
@@ -554,7 +554,6 @@ class Expression implements \ArrayAccess, \IteratorAggregate
                     }
                 }
 
-                $statement->setFetchMode(\PDO::FETCH_ASSOC);
                 $statement->execute();
             } catch (DbalException | \Doctrine\DBAL\DBALException $e) { // @phpstan-ignore-line
                 $errorInfo = $e->getPrevious() !== null && $e->getPrevious() instanceof \PDOException

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -578,13 +578,13 @@ class Expression implements \ArrayAccess, \IteratorAggregate
     /**
      * TODO drop support for \IteratorAggregate.
      */
-    public function getIterator(): iterable
+    public function getIterator(): \Traversable
     {
         if (Connection::isComposerDbal2x()) {
             return $this->execute();
         }
 
-        return new \IteratorIterator($this->execute()->iterateAssociative());
+        return $this->execute()->iterateAssociative();
     }
 
     // {{{ Result Querying

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -560,11 +560,13 @@ class Expression implements \ArrayAccess, \IteratorAggregate
 
                 return $result;
             } catch (DbalException | \Doctrine\DBAL\DBALException $e) { // @phpstan-ignore-line
-                $errorInfo = $e->getPrevious() !== null && $e->getPrevious() instanceof \PDOException
-                    ? $e->getPrevious()->errorInfo
-                    : null;
+                $firstException = $e;
+                while ($firstException->getPrevious() !== null) {
+                    $firstException = $firstException->getPrevious();
+                }
+                $errorInfo = $firstException instanceof \PDOException ? $firstException->errorInfo : null;
 
-                $new = (new ExecuteException('DSQL got Exception when executing this query', $errorInfo[1] ?? 0))
+                $new = (new ExecuteException('Dsql execute error', $errorInfo[1] ?? 0, $e))
                     ->addMoreInfo('error', $errorInfo[2] ?? 'n/a (' . $errorInfo[0] . ')')
                     ->addMoreInfo('query', $this->getDebugQuery());
 

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace atk4\dsql;
 
 use Doctrine\DBAL\Connection as DbalConnection;
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DbalException;
 
 class Expression implements \ArrayAccess, \IteratorAggregate
 {
@@ -556,7 +556,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
 
                 $statement->setFetchMode(\PDO::FETCH_ASSOC);
                 $statement->execute();
-            } catch (DBALException $e) {
+            } catch (DbalException | \Doctrine\DBAL\DBALException $e) { // @phpstan-ignore-line
                 $errorInfo = $e->getPrevious() !== null && $e->getPrevious() instanceof \PDOException
                     ? $e->getPrevious()->errorInfo
                     : null;

--- a/src/Mssql/ExpressionTrait.php
+++ b/src/Mssql/ExpressionTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace atk4\dsql\Mssql;
 
+use Doctrine\DBAL\Result as DbalResult;
+
 trait ExpressionTrait
 {
     protected function escapeIdentifier(string $value): string
@@ -26,7 +28,10 @@ trait ExpressionTrait
     private $numQueryParamsBackup;
     private $numQueryRender;
 
-    public function execute(object $connection = null)
+    /**
+     * @return DbalResult|\PDOStatement PDOStatement iff for DBAL 2.x
+     */
+    public function execute(object $connection = null): object
     {
         if ($this->numQueryParamsBackup !== null) {
             return parent::execute($connection);

--- a/src/Oracle/Connection.php
+++ b/src/Oracle/Connection.php
@@ -67,7 +67,11 @@ class Connection extends BaseConnection
                 $dbalConnection = parent::connectDbalConnection($dsn);
             }
 
-            self::$ciLastConnectPdo = $dbalConnection->getWrappedConnection();
+            if (BaseConnection::isComposerDbal2x()) {
+                self::$ciLastConnectPdo = $dbalConnection->getWrappedConnection();
+            } else {
+                self::$ciLastConnectPdo = $dbalConnection->getWrappedConnection()->getWrappedConnection();
+            }
             self::$ciLastConnectDsn = $dsn;
 
             return $dbalConnection;

--- a/src/Oracle/Query.php
+++ b/src/Oracle/Query.php
@@ -34,7 +34,7 @@ class Query extends AbstractQuery
             max((int) ($this->args['limit']['cnt'] + $this->args['limit']['shift']), (int) $this->args['limit']['cnt']);
     }
 
-    public function getIterator(): iterable
+    public function getIterator(): \Traversable
     {
         foreach (parent::getIterator() as $row) {
             unset($row['__dsql_rownum']);

--- a/src/Query.php
+++ b/src/Query.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace atk4\dsql;
 
+use Doctrine\DBAL\Result as DbalResult;
+
 /**
  * Perform query operation on SQL server (such as select, insert, delete, etc).
  */
@@ -987,9 +989,9 @@ class Query extends Expression
     /**
      * Execute select statement.
      *
-     * @return \PDOStatement
+     * @return DbalResult|\PDOStatement PDOStatement iff for DBAL 2.x
      */
-    public function select()
+    public function select(): object
     {
         return $this->mode('select')->execute();
     }
@@ -997,9 +999,9 @@ class Query extends Expression
     /**
      * Execute insert statement.
      *
-     * @return \PDOStatement
+     * @return DbalResult|\PDOStatement PDOStatement iff for DBAL 2.x
      */
-    public function insert()
+    public function insert(): object
     {
         return $this->mode('insert')->execute();
     }
@@ -1007,9 +1009,9 @@ class Query extends Expression
     /**
      * Execute update statement.
      *
-     * @return \PDOStatement
+     * @return DbalResult|\PDOStatement PDOStatement iff for DBAL 2.x
      */
-    public function update()
+    public function update(): object
     {
         return $this->mode('update')->execute();
     }
@@ -1017,9 +1019,9 @@ class Query extends Expression
     /**
      * Execute replace statement.
      *
-     * @return \PDOStatement
+     * @return DbalResult|\PDOStatement PDOStatement iff for DBAL 2.x
      */
-    public function replace()
+    public function replace(): object
     {
         return $this->mode('replace')->execute();
     }
@@ -1027,9 +1029,9 @@ class Query extends Expression
     /**
      * Execute delete statement.
      *
-     * @return \PDOStatement
+     * @return DbalResult|\PDOStatement PDOStatement iff for DBAL 2.x
      */
-    public function delete()
+    public function delete(): object
     {
         return $this->mode('delete')->execute();
     }
@@ -1037,9 +1039,9 @@ class Query extends Expression
     /**
      * Execute truncate statement.
      *
-     * @return \PDOStatement
+     * @return DbalResult|\PDOStatement PDOStatement iff for DBAL 2.x
      */
-    public function truncate()
+    public function truncate(): object
     {
         return $this->mode('truncate')->execute();
     }

--- a/tests/WithDb/ConnectionTest.php
+++ b/tests/WithDb/ConnectionTest.php
@@ -6,8 +6,6 @@ namespace atk4\dsql\tests\WithDb;
 
 use atk4\core\AtkPhpunit;
 use atk4\dsql\Connection;
-use atk4\dsql\Expression;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 
 /**
@@ -24,32 +22,4 @@ class ConnectionTest extends AtkPhpunit\TestCase
 
         return (string) $c->expr('SELECT 1' . ($c->getDatabasePlatform() instanceof OraclePlatform ? ' FROM DUAL' : ''))->getOne();
     }
-
-    public function testGenerator()
-    {
-        $c = new HelloWorldConnection();
-        $test = 0;
-        foreach ($c->expr('abrakadabra') as $row) {
-            ++$test;
-        }
-        $this->assertSame(10, $test);
-    }
-}
-
-// @codingStandardsIgnoreStart
-class HelloWorldConnection extends Connection
-{
-    public function getDatabasePlatform(): AbstractPlatform
-    {
-        throw new \atk4\dsql\Exception('Not implemented');
-    }
-
-    public function execute(Expression $e)
-    {
-        for ($x = 0; $x < 10; ++$x) {
-            yield $x => ['greeting' => 'Hello World'];
-        }
-    }
-
-    // @codingStandardsIgnoreEnd
 }

--- a/tests/WithDb/SelectTest.php
+++ b/tests/WithDb/SelectTest.php
@@ -10,8 +10,8 @@ use atk4\dsql\Exception;
 use atk4\dsql\Expression;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 
 class SelectTest extends AtkPhpunit\TestCase
 {
@@ -46,7 +46,7 @@ class SelectTest extends AtkPhpunit\TestCase
             return preg_replace_callback('~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K"([^\'"()\[\]{}]*?)"~s', function ($matches) {
                 if ($this->c->getDatabasePlatform() instanceof MySQLPlatform) {
                     return '`' . $matches[1] . '`';
-                } elseif ($this->c->getDatabasePlatform() instanceof SQLServerPlatform) {
+                } elseif ($this->c->getDatabasePlatform() instanceof SQLServer2012Platform) {
                     return '[' . $matches[1] . ']';
                 }
 
@@ -64,7 +64,7 @@ class SelectTest extends AtkPhpunit\TestCase
                 return '"' . $v . '"';
             }, array_keys($row))) . ') VALUES(' . implode(', ', array_map(function ($v) {
                 if (is_bool($v)) {
-                    if ($this->c->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+                    if ($this->c->getDatabasePlatform() instanceof PostgreSQL94Platform) {
                         return $v ? 'true' : 'false';
                     }
 
@@ -144,7 +144,7 @@ class SelectTest extends AtkPhpunit\TestCase
          * But CAST(.. AS int) does not work in mysql. So we use two different tests..
          * (CAST(.. AS int) will work on mariaDB, whereas mysql needs it to be CAST(.. AS signed))
          */
-        if ($this->c->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+        if ($this->c->getDatabasePlatform() instanceof PostgreSQL94Platform) {
             $this->assertSame(
                 [['now' => '6']],
                 $this->q()->field(new Expression('CAST([] AS int)+CAST([] AS int)', [3, 3]), 'now')->getRows()
@@ -170,7 +170,7 @@ class SelectTest extends AtkPhpunit\TestCase
          * But using CAST(.. AS CHAR) will return one single character on postgresql, but the
          * entire string on mysql.
          */
-        if ($this->c->getDatabasePlatform() instanceof PostgreSQLPlatform || $this->c->getDatabasePlatform() instanceof SQLServerPlatform) {
+        if ($this->c->getDatabasePlatform() instanceof PostgreSQL94Platform || $this->c->getDatabasePlatform() instanceof SQLServer2012Platform) {
             $this->assertSame(
                 'foo',
                 $this->e('select CAST([] AS VARCHAR)', ['foo'])->getOne()
@@ -220,7 +220,7 @@ class SelectTest extends AtkPhpunit\TestCase
         );
 
         // replace
-        if ($this->c->getDatabasePlatform() instanceof PostgreSQLPlatform || $this->c->getDatabasePlatform() instanceof SQLServerPlatform || $this->c->getDatabasePlatform() instanceof OraclePlatform) {
+        if ($this->c->getDatabasePlatform() instanceof PostgreSQL94Platform || $this->c->getDatabasePlatform() instanceof SQLServer2012Platform || $this->c->getDatabasePlatform() instanceof OraclePlatform) {
             $this->q('employee')
                 ->set(['name' => 'Peter', 'surname' => 'Doe', 'retired' => 1])
                 ->where('id', 1)

--- a/tests/WithDb/TransactionTest.php
+++ b/tests/WithDb/TransactionTest.php
@@ -10,8 +10,8 @@ use atk4\dsql\Exception;
 use atk4\dsql\Expression;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 
 class TransactionTest extends AtkPhpunit\TestCase
 {
@@ -46,7 +46,7 @@ class TransactionTest extends AtkPhpunit\TestCase
             return preg_replace_callback('~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K"([^\'"()\[\]{}]*?)"~s', function ($matches) {
                 if ($this->c->getDatabasePlatform() instanceof MySQLPlatform) {
                     return '`' . $matches[1] . '`';
-                } elseif ($this->c->getDatabasePlatform() instanceof SQLServerPlatform) {
+                } elseif ($this->c->getDatabasePlatform() instanceof SQLServer2012Platform) {
                     return '[' . $matches[1] . ']';
                 }
 
@@ -64,7 +64,7 @@ class TransactionTest extends AtkPhpunit\TestCase
                 return '"' . $v . '"';
             }, array_keys($row))) . ') VALUES(' . implode(', ', array_map(function ($v) {
                 if (is_bool($v)) {
-                    if ($this->c->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+                    if ($this->c->getDatabasePlatform() instanceof PostgreSQL94Platform) {
                         return $v ? 'true' : 'false';
                     }
 


### PR DESCRIPTION
- PDO instance can not be used to create DBAL Connection, but we emulate support for BC
- some DBAL platform classes are removed, see https://github.com/doctrine/dbal/pull/3912, you need to adjust your code to check platform against the lowest supported in DBAL 3.x (PHPStan can detect unknown classes with level 1)
- `execute` returns `Doctrine\DBAL\Statement` which does no longer implement a lot of `PDOStatement` like methods