### PR TITLE
[fix] destroy connection on test teardown

### DIFF
--- a/src/Oracle/Connection.php
+++ b/src/Oracle/Connection.php
@@ -22,66 +22,6 @@ class Connection extends BaseConnection
         ])->execute();
     }
 
-    // {{{ fix for too many connections for CI testing
-
-    /** @var int */
-    private static $ciDifferentDsnCounter = 0;
-    /** @var array */
-    private static $ciLastConnectDsn;
-    /** @var \PDO */
-    private static $ciLastConnectPdo;
-
-    protected static function connectDbalConnection(array $dsn)
-    {
-        // for some reasons, the following error:
-        // PDOException: SQLSTATE[HY000]: pdo_oci_handle_factory: ORA-12516: TNS:listener could not find available handler with matching protocol stack
-        // is shown randomly when a lot of connections are created in tests,
-        // so for CI, fix this issue by reusing the previous PDO connection
-        // TODO remove once atk4/data tests can be run consistently without errors
-        if (class_exists(\PHPUnit\Framework\TestCase::class, false)) { // called from phpunit
-            $notReusableFunc = function (string $message): void {
-                echo "\n" . 'connection for CI can not be reused:' . "\n" . $message . "\n";
-                self::$ciLastConnectPdo = null;
-            };
-
-            if (self::$ciLastConnectDsn !== $dsn) {
-                ++self::$ciDifferentDsnCounter;
-                if (self::$ciDifferentDsnCounter >= 4) {
-                    $notReusableFunc('different DSN');
-                }
-            } elseif (self::$ciLastConnectPdo !== null) {
-                try {
-                    self::$ciLastConnectPdo->query('select 1 from dual')->fetch();
-                } catch (\PDOException $e) {
-                    $notReusableFunc((string) $e);
-                }
-            }
-
-            if (self::$ciLastConnectPdo !== null && self::$ciLastConnectPdo->inTransaction()) {
-                $notReusableFunc('inside transaction');
-            }
-
-            if (self::$ciLastConnectPdo !== null) {
-                $dbalConnection = parent::connectDbalConnection(['pdo' => self::$ciLastConnectPdo]);
-            } else {
-                $dbalConnection = parent::connectDbalConnection($dsn);
-            }
-
-            if (BaseConnection::isComposerDbal2x()) {
-                self::$ciLastConnectPdo = $dbalConnection->getWrappedConnection();
-            } else {
-                self::$ciLastConnectPdo = $dbalConnection->getWrappedConnection()->getWrappedConnection(); // @phpstan-ignore-line
-            }
-            self::$ciLastConnectDsn = $dsn;
-
-            return $dbalConnection;
-        }
-
-        return parent::connectDbalConnection($dsn);
-    }
-
-    /// }}}
-
     /**
      * Return last inserted ID value.
      *

--- a/src/Oracle/Connection.php
+++ b/src/Oracle/Connection.php
@@ -22,6 +22,66 @@ class Connection extends BaseConnection
         ])->execute();
     }
 
+    // {{{ fix for too many connections for CI testing
+
+    /** @var int */
+    private static $ciDifferentDsnCounter = 0;
+    /** @var array */
+    private static $ciLastConnectDsn;
+    /** @var \PDO */
+    private static $ciLastConnectPdo;
+
+    protected static function connectDbalConnection(array $dsn)
+    {
+        // for some reasons, the following error:
+        // PDOException: SQLSTATE[HY000]: pdo_oci_handle_factory: ORA-12516: TNS:listener could not find available handler with matching protocol stack
+        // is shown randomly when a lot of connections are created in tests,
+        // so for CI, fix this issue by reusing the previous PDO connection
+        // TODO remove once atk4/data tests can be run consistently without errors
+        if (class_exists(\PHPUnit\Framework\TestCase::class, false)) { // called from phpunit
+            $notReusableFunc = function (string $message): void {
+                echo "\n" . 'connection for CI can not be reused:' . "\n" . $message . "\n";
+                self::$ciLastConnectPdo = null;
+            };
+
+            if (self::$ciLastConnectDsn !== $dsn) {
+                ++self::$ciDifferentDsnCounter;
+                if (self::$ciDifferentDsnCounter >= 4) {
+                    $notReusableFunc('different DSN');
+                }
+            } elseif (self::$ciLastConnectPdo !== null) {
+                try {
+                    self::$ciLastConnectPdo->query('select 1 from dual')->fetch();
+                } catch (\PDOException $e) {
+                    $notReusableFunc((string) $e);
+                }
+            }
+
+            if (self::$ciLastConnectPdo !== null && self::$ciLastConnectPdo->inTransaction()) {
+                $notReusableFunc('inside transaction');
+            }
+
+            if (self::$ciLastConnectPdo !== null) {
+                $dbalConnection = parent::connectDbalConnection(['pdo' => self::$ciLastConnectPdo]);
+            } else {
+                $dbalConnection = parent::connectDbalConnection($dsn);
+            }
+
+            if (BaseConnection::isComposerDbal2x()) {
+                self::$ciLastConnectPdo = $dbalConnection->getWrappedConnection();
+            } else {
+                self::$ciLastConnectPdo = $dbalConnection->getWrappedConnection()->getWrappedConnection(); // @phpstan-ignore-line
+            }
+            self::$ciLastConnectDsn = $dsn;
+
+            return $dbalConnection;
+        }
+
+        return parent::connectDbalConnection($dsn);
+    }
+
+    /// }}}
+
     /**
      * Return last inserted ID value.
      *

--- a/tests/WithDb/SelectTest.php
+++ b/tests/WithDb/SelectTest.php
@@ -81,6 +81,8 @@ class SelectTest extends AtkPhpunit\TestCase
     protected function tearDown(): void
     {
         $this->dropDbIfExists();
+
+        $this->c = null;
     }
 
     private function q($table = null, $alias = null)

--- a/tests/WithDb/TransactionTest.php
+++ b/tests/WithDb/TransactionTest.php
@@ -81,6 +81,8 @@ class TransactionTest extends AtkPhpunit\TestCase
     protected function tearDown(): void
     {
         $this->dropDbIfExists();
+
+        $this->c = null;
     }
 
     private function q($table = null, $alias = null)


### PR DESCRIPTION
Fix for Burn test "Too many connections" failure