### PR TITLE
[update] add support for Query::orExpr()->having(...)

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -780,20 +780,20 @@ class Query extends Expression
 
     protected function _render_orwhere()
     {
-        if (!isset($this->args['where'])) {
-            return;
+        foreach (['where', 'having'] as $kind) {
+            if (isset($this->args[$kind])) {
+                return implode(' or ', $this->_sub_render_where($kind));
+            }
         }
-
-        return implode(' or ', $this->_sub_render_where('where'));
     }
 
     protected function _render_andwhere()
     {
-        if (!isset($this->args['where'])) {
-            return;
+        foreach (['where', 'having'] as $kind) {
+            if (isset($this->args[$kind])) {
+                return implode(' and ', $this->_sub_render_where($kind));
+            }
         }
-
-        return implode(' and ', $this->_sub_render_where('where'));
     }
 
     protected function _render_having()

--- a/src/Query.php
+++ b/src/Query.php
@@ -780,6 +780,10 @@ class Query extends Expression
 
     protected function _render_orwhere()
     {
+        if (isset($this->args['where']) && isset($this->args['having'])) {
+            throw new Exception('Mixing of WHERE and HAVING conditions not allowed in query expression');
+        }
+
         foreach (['where', 'having'] as $kind) {
             if (isset($this->args[$kind])) {
                 return implode(' or ', $this->_sub_render_where($kind));
@@ -789,6 +793,10 @@ class Query extends Expression
 
     protected function _render_andwhere()
     {
+        if (isset($this->args['where']) && isset($this->args['having'])) {
+            throw new Exception('Mixing of WHERE and HAVING conditions not allowed in query expression');
+        }
+
         foreach (['where', 'having'] as $kind) {
             if (isset($this->args[$kind])) {
                 return implode(' and ', $this->_sub_render_where($kind));

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1537,6 +1537,7 @@ class QueryTest extends AtkPhpunit\TestCase
 
     public function testNestedOrAndHaving()
     {
+        // test 1
         $q = $this->q();
         $q->table('employee')->field(new Expression('sum([])', ['amount']), 'salary')->group('type');
         $q->having(
@@ -1547,6 +1548,20 @@ class QueryTest extends AtkPhpunit\TestCase
         );
         $this->assertSame(
             'select sum(:a) "salary" from "employee" group by "type" having ("a" = :b or "b" = :c)',
+            $q->render()
+        );
+
+        // test 2
+        $q = $this->q();
+        $q->table('employee')->field(new Expression('sum([])', ['amount']), 'salary')->group('type');
+        $q->having(
+            $q
+                ->orExpr()
+                ->where('a', 1)
+                ->having('b', 1) // disregarded
+        );
+        $this->assertSame(
+            'select sum(:a) "salary" from "employee" group by "type" having ("a" = :b)',
             $q->render()
         );
     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1537,7 +1537,6 @@ class QueryTest extends AtkPhpunit\TestCase
 
     public function testNestedOrAndHaving()
     {
-        // test 1
         $q = $this->q();
         $q->table('employee')->field(new Expression('sum([])', ['amount']), 'salary')->group('type');
         $q->having(
@@ -1550,20 +1549,21 @@ class QueryTest extends AtkPhpunit\TestCase
             'select sum(:a) "salary" from "employee" group by "type" having ("a" = :b or "b" = :c)',
             $q->render()
         );
+    }
 
-        // test 2
+    public function testNestedOrAndHavingWithWhereException()
+    {
         $q = $this->q();
         $q->table('employee')->field(new Expression('sum([])', ['amount']), 'salary')->group('type');
         $q->having(
             $q
                 ->orExpr()
                 ->where('a', 1)
-                ->having('b', 1) // disregarded
+                ->having('b', 1) // mixing triggers Exception on render
         );
-        $this->assertSame(
-            'select sum(:a) "salary" from "employee" group by "type" having ("a" = :b)',
-            $q->render()
-        );
+
+        $this->expectException(Exception::class);
+        $q->render();
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1535,6 +1535,22 @@ class QueryTest extends AtkPhpunit\TestCase
         );
     }
 
+    public function testNestedOrAndHaving()
+    {
+        $q = $this->q();
+        $q->table('employee')->field(new Expression('sum([])', ['amount']), 'salary')->group('type');
+        $q->having(
+            $q
+                ->orExpr()
+                ->having('a', 1)
+                ->having('b', 1)
+        );
+        $this->assertSame(
+            'select sum(:a) "salary" from "employee" group by "type" having ("a" = :b or "b" = :c)',
+            $q->render()
+        );
+    }
+
     /**
      * Test reset().
      *


### PR DESCRIPTION
Query::orExpr()->having(...) does not render the conditions.

This can be overcome by using Query::orExpr()->where(...) but then code is not consistent.

Fixes #280

(Failure caught when creating tests for `\atk4\data\Model\Aggregate`)