### PR TITLE
Upgrade DBAL to >= 2.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,13 @@
     "php": ">=7.3.0",
     "ext-pdo": "*",
     "atk4/core": "dev-develop",
-    "doctrine/dbal": "^2.9.3 || ^3.0"
+    "doctrine/dbal": "^2.10 || ^3.0"
   },
   "require-release": {
     "php": ">=7.3.0",
     "ext-pdo": "*",
     "atk4/core": "~2.3.0",
-    "doctrine/dbal": "^2.9.3 || ^3.0"
+    "doctrine/dbal": "^2.10 || ^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
we can then use types enum up too the lastest 3.x DBAL version

we can upgrade because ORM 2.8.x was released