### PR TITLE
Unimplement IteratorAggregate on Expression

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection as DbalConnection;
 use Doctrine\DBAL\Exception as DbalException;
 use Doctrine\DBAL\Result as DbalResult;
 
-class Expression implements \ArrayAccess, \IteratorAggregate
+class Expression implements \ArrayAccess
 {
     /** @const string "[]" in template, escape as parameter */
     protected const ESCAPE_PARAM = 'param';
@@ -579,7 +579,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * TODO drop support for \IteratorAggregate.
+     * TODO drop method once we support DBAL 3.x only.
      */
     public function getIterator(): \Traversable
     {

--- a/tests/WithDb/SelectTest.php
+++ b/tests/WithDb/SelectTest.php
@@ -127,7 +127,7 @@ class SelectTest extends AtkPhpunit\TestCase
         );
 
         $names = [];
-        foreach ($this->q('employee')->where('retired', false) as $row) {
+        foreach ($this->q('employee')->where('retired', false)->getIterator() as $row) {
             $names[] = $row['name'];
         }
 


### PR DESCRIPTION
to explicitly force user to call `execute` (which is slow/requires DB query)