### PR TITLE
Upgrade phpstan to level 6

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - ./
     excludes_analyse:
@@ -9,6 +9,18 @@ parameters:
 
     # TODO review once we drop PHP 7.x support
     treatPhpDocTypesAsCertain: false
+
+    # some extra rules
+    checkAlwaysTrueCheckTypeFunctionCall: true
+    checkAlwaysTrueInstanceof: true
+    checkAlwaysTrueStrictComparison: true
+    checkExplicitMixedMissingReturn: true
+    checkFunctionNameCase: true
+    # TODO checkMissingClosureNativeReturnTypehintRule: true
+    reportMaybesInMethodSignatures: true
+    reportStaticMethodSignatures: true
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    checkMissingIterableValueType: false # TODO
 
     ignoreErrors:
         - '~^Unsafe usage of new static\(\)\.$~'

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -160,7 +160,7 @@ abstract class Connection
      * @param string $connectionClass
      * @param string $driverSchema
      */
-    public static function registerConnectionClass($connectionClass = null, $driverSchema = null)
+    public static function registerConnectionClass($connectionClass = null, $driverSchema = null): void
     {
         if ($connectionClass === null) {
             $connectionClass = static::class;
@@ -508,6 +508,10 @@ abstract class Connection
      * Atomic executes operations within one begin/end transaction, so if
      * the code inside callback will fail, then all of the transaction
      * will be also rolled back.
+     *
+     * @param mixed ...$args
+     *
+     * @return mixed
      */
     public function atomic(\Closure $fx, ...$args)
     {

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -59,7 +59,7 @@ class Expression implements Expressionable, \ArrayAccess
     /** @var array Populated with actual values by escapeParam() */
     public $params = [];
 
-    /** @var Connection */
+    /** @var Connection|null */
     public $connection;
 
     /** @var bool Wrap the expression in parentheses when consumed by another expression or not. */
@@ -183,17 +183,13 @@ class Expression implements Expressionable, \ArrayAccess
      */
     public function expr($properties = [], $arguments = null)
     {
-        // If we use DSQL Connection, then we should call expr() from there.
-        // Connection->expr() will return correct, connection specific Expression class.
-        if ($this->connection instanceof Connection) {
+        if ($this->connection !== null) {
             // TODO - condition above always satisfied when connection is set - adjust tests,
             // so connection is always set and remove the code below
             return $this->connection->expr($properties, $arguments);
         }
 
-        // Otherwise, connection is probably PDO and we don't know which Expression
-        // class to use, so we make a smart guess :)
-        // @phpstan-ignore-next-line
+        // make a smart guess :) when connection is not set
         if ($this instanceof Query) {
             $e = new self($properties, $arguments);
         } else {
@@ -201,7 +197,6 @@ class Expression implements Expressionable, \ArrayAccess
         }
 
         $e->escape_char = $this->escape_char;
-        $e->connection = $this->connection;
 
         return $e;
     }

--- a/src/Mssql/ExpressionTrait.php
+++ b/src/Mssql/ExpressionTrait.php
@@ -25,7 +25,9 @@ trait ExpressionTrait
 
     // {{{ MSSQL does not support named parameters, so convert them to numerical inside execute
 
+    /** @var array|null */
     private $numQueryParamsBackup;
+    /** @var string|null */
     private $numQueryRender;
 
     /**
@@ -61,7 +63,7 @@ trait ExpressionTrait
         }
     }
 
-    public function render()
+    public function render(): string
     {
         if ($this->numQueryParamsBackup !== null) {
             return $this->numQueryRender;

--- a/src/Mssql/Query.php
+++ b/src/Mssql/Query.php
@@ -22,16 +22,18 @@ class Query extends BaseQuery
         . "\n" . 'set IDENTITY_INSERT [table_noalias] off'
         . "\n" . 'end end catch';
 
-    public function _render_limit()
+    public function _render_limit(): ?string
     {
-        if (isset($this->args['limit'])) {
-            $cnt = (int) $this->args['limit']['cnt'];
-            $shift = (int) $this->args['limit']['shift'];
-
-            return (!isset($this->args['order']) ? ' order by (select null)' : '')
-                . ' offset ' . $shift . ' rows'
-                . ' fetch next ' . $cnt . ' rows only';
+        if (!isset($this->args['limit'])) {
+            return null;
         }
+
+        $cnt = (int) $this->args['limit']['cnt'];
+        $shift = (int) $this->args['limit']['shift'];
+
+        return (!isset($this->args['order']) ? ' order by (select null)' : '')
+            . ' offset ' . $shift . ' rows'
+            . ' fetch next ' . $cnt . ' rows only';
     }
 
     public function groupConcat($field, string $delimiter = ',')

--- a/src/Oracle/AbstractQuery.php
+++ b/src/Oracle/AbstractQuery.php
@@ -13,7 +13,7 @@ abstract class AbstractQuery extends BaseQuery
     /** @var string */
     protected $template_seq_nextval = '[sequence].NEXTVAL';
 
-    public function render()
+    public function render(): string
     {
         if ($this->mode === 'select' && $this->main_table === null) {
             $this->table('DUAL');
@@ -36,7 +36,7 @@ abstract class AbstractQuery extends BaseQuery
         return $this;
     }
 
-    public function _render_sequence()
+    public function _render_sequence(): ?string
     {
         return $this->args['sequence'];
     }

--- a/src/Oracle/Query.php
+++ b/src/Oracle/Query.php
@@ -9,6 +9,7 @@ class Query extends AbstractQuery
     // {{{ for Oracle 11 and lower to support LIMIT with OFFSET
 
     protected $template_select = '[with]select[option] [field] [from] [table][join][where][group][having][order]';
+    /** @var string */
     protected $template_select_limit = 'select * from (select "__t".*, rownum "__dsql_rownum" [from] ([with]select[option] [field] [from] [table][join][where][group][having][order]) "__t") where "__dsql_rownum" > [limit_start][and_limit_end]';
 
     public function limit($cnt, $shift = null)
@@ -19,12 +20,12 @@ class Query extends AbstractQuery
         return parent::limit($cnt, $shift);
     }
 
-    public function _render_limit_start()
+    public function _render_limit_start(): string
     {
-        return (int) $this->args['limit']['shift'];
+        return $this->args['limit']['shift'] ?? '0';
     }
 
-    public function _render_and_limit_end()
+    public function _render_and_limit_end(): ?string
     {
         if (!$this->args['limit']['cnt']) {
             return '';

--- a/src/Oracle/Version12/Query.php
+++ b/src/Oracle/Version12/Query.php
@@ -8,19 +8,21 @@ use Atk4\Dsql\Oracle\AbstractQuery;
 
 class Query extends AbstractQuery
 {
-    public function _render_limit()
+    public function _render_limit(): ?string
     {
-        if (isset($this->args['limit'])) {
-            $cnt = (int) $this->args['limit']['cnt'];
-            $shift = (int) $this->args['limit']['shift'];
-
-            return ' ' . trim(
-                ($shift ? 'OFFSET ' . $shift . ' ROWS' : '') .
-                ' ' .
-                // as per spec 'NEXT' is synonymous to 'FIRST', so not bothering with it.
-                // https://docs.oracle.com/javadb/10.8.3.0/ref/rrefsqljoffsetfetch.html
-                ($cnt ? 'FETCH NEXT ' . $cnt . ' ROWS ONLY' : '')
-            );
+        if (!isset($this->args['limit'])) {
+            return null;
         }
+
+        $cnt = (int) $this->args['limit']['cnt'];
+        $shift = (int) $this->args['limit']['shift'];
+
+        return ' ' . trim(
+            ($shift ? 'OFFSET ' . $shift . ' ROWS' : '') .
+            ' ' .
+            // as per spec 'NEXT' is synonymous to 'FIRST', so not bothering with it.
+            // https://docs.oracle.com/javadb/10.8.3.0/ref/rrefsqljoffsetfetch.html
+            ($cnt ? 'FETCH NEXT ' . $cnt . ' ROWS ONLY' : '')
+        );
     }
 }

--- a/src/Postgresql/Query.php
+++ b/src/Postgresql/Query.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Dsql\Postgresql;
 
+use Atk4\Dsql\Expression;
 use Atk4\Dsql\Query as BaseQuery;
 
 class Query extends BaseQuery
@@ -11,17 +12,19 @@ class Query extends BaseQuery
     protected $template_update = 'update [table][join] set [set] [where]';
     protected $template_replace;
 
-    public function _render_limit()
+    public function _render_limit(): ?string
     {
-        if (isset($this->args['limit'])) {
-            return ' limit ' .
-                (int) $this->args['limit']['cnt'] .
-                ' offset ' .
-                (int) $this->args['limit']['shift'];
+        if (!isset($this->args['limit'])) {
+            return null;
         }
+
+        return ' limit ' .
+            (int) $this->args['limit']['cnt'] .
+            ' offset ' .
+            (int) $this->args['limit']['shift'];
     }
 
-    public function groupConcat($field, string $delimiter = ',')
+    public function groupConcat($field, string $delimiter = ','): Expression
     {
         return $this->expr('string_agg({}, [])', [$field, $delimiter]);
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -172,7 +172,7 @@ class Query extends Expression
             $ret[] = $field;
         }
 
-        return implode(',', $ret);
+        return implode(', ', $ret);
     }
 
     protected function _render_field_noalias()
@@ -279,7 +279,7 @@ class Query extends Expression
             $ret[] = $table;
         }
 
-        return implode(',', $ret);
+        return implode(', ', $ret);
     }
 
     protected function _render_table_noalias()
@@ -349,7 +349,7 @@ class Query extends Expression
 
             // set cursor fields
             if ($fields !== null) {
-                $s .= '(' . implode(',', array_map([$this, 'escapeIdentifier'], $fields)) . ') ';
+                $s .= '(' . implode(', ', array_map([$this, 'escapeIdentifier'], $fields)) . ') ';
             }
 
             // will parameterize the value and escape if necessary
@@ -361,7 +361,7 @@ class Query extends Expression
             $ret[] = $s;
         }
 
-        return 'with ' . ($isRecursive ? 'recursive ' : '') . implode(',', $ret) . ' ';
+        return 'with ' . ($isRecursive ? 'recursive ' : '') . implode(', ', $ret) . ' ';
     }
 
     /// }}}
@@ -730,7 +730,7 @@ class Query extends Expression
                 return '1 = 1'; // always true
             }
 
-            $value = '(' . implode(',', array_map(function ($v) { return $this->escapeParam($v); }, $value)) . ')';
+            $value = '(' . implode(', ', array_map(function ($v) { return $this->escapeParam($v); }, $value)) . ')';
 
             return $field . ' ' . $cond . ' ' . $value;
         }
@@ -899,7 +899,7 @@ class Query extends Expression
             }
         }
 
-        return implode(',', $ret);
+        return implode(', ', $ret);
     }
 
     protected function _render_set_values()
@@ -915,7 +915,7 @@ class Query extends Expression
             }
         }
 
-        return implode(',', $ret);
+        return implode(', ', $ret);
     }
 
     // }}}

--- a/src/Query.php
+++ b/src/Query.php
@@ -30,10 +30,8 @@ class Query extends Expression
     /** @var string Expression classname */
     protected $expression_class = Expression::class;
 
+    /** @var bool */
     public $wrapInParentheses = true;
-
-    /** @deprecated use $consumeWrappedInParenthesis instead - will be removed in version 2.5 */
-    public $allowToWrapInParenthesis;
 
     /** @var string */
     protected $template_select = '[with]select[option] [field] [from] [table][join][where][group][having][order][limit]';
@@ -133,7 +131,7 @@ class Query extends Expression
      *
      * @return string Parsed template chunk
      */
-    protected function _render_field($add_alias = true)
+    protected function _render_field($add_alias = true): string
     {
         // will be joined for output
         $ret = [];
@@ -175,7 +173,7 @@ class Query extends Expression
         return implode(', ', $ret);
     }
 
-    protected function _render_field_noalias()
+    protected function _render_field_noalias(): string
     {
         return $this->_render_field(false);
     }
@@ -240,7 +238,7 @@ class Query extends Expression
     /**
      * @param bool $add_alias Should we add aliases, see _render_table_noalias()
      */
-    protected function _render_table($add_alias = true)
+    protected function _render_table($add_alias = true): ?string
     {
         // will be joined for output
         $ret = [];
@@ -282,12 +280,12 @@ class Query extends Expression
         return implode(', ', $ret);
     }
 
-    protected function _render_table_noalias()
+    protected function _render_table_noalias(): ?string
     {
         return $this->_render_table(false);
     }
 
-    protected function _render_from()
+    protected function _render_from(): ?string
     {
         return empty($this->args['table']) ? '' : 'from';
     }
@@ -332,7 +330,7 @@ class Query extends Expression
         return $this->with($cursor, $alias, $fields, true);
     }
 
-    protected function _render_with()
+    protected function _render_with(): ?string
     {
         // will be joined for output
         $ret = [];
@@ -475,7 +473,7 @@ class Query extends Expression
         return $this;
     }
 
-    public function _render_join()
+    public function _render_join(): ?string
     {
         if (!isset($this->args['join'])) {
             return '';
@@ -629,9 +627,9 @@ class Query extends Expression
     /**
      * Same syntax as where().
      *
-     * @param mixed  $field Field or Expression
-     * @param string $cond  Condition such as '=', '>' or 'is not'
-     * @param string $value Value. Will be quoted unless you pass expression
+     * @param mixed $field Field or Expression
+     * @param mixed $cond  Condition such as '=', '>' or 'is not'
+     * @param mixed $value Value. Will be quoted unless you pass expression
      *
      * @return $this
      */
@@ -661,7 +659,7 @@ class Query extends Expression
         return $ret;
     }
 
-    protected function _sub_render_condition($row)
+    protected function _sub_render_condition(array $row): string
     {
         if (count($row) === 3) {
             [$field, $cond, $value] = $row;
@@ -742,16 +740,16 @@ class Query extends Expression
         return $field . ' ' . $cond . ' ' . $value;
     }
 
-    protected function _render_where()
+    protected function _render_where(): ?string
     {
         if (!isset($this->args['where'])) {
-            return;
+            return null;
         }
 
         return ' where ' . implode(' and ', $this->_sub_render_where('where'));
     }
 
-    protected function _render_orwhere()
+    protected function _render_orwhere(): ?string
     {
         if (isset($this->args['where']) && isset($this->args['having'])) {
             throw new Exception('Mixing of WHERE and HAVING conditions not allowed in query expression');
@@ -762,9 +760,11 @@ class Query extends Expression
                 return implode(' or ', $this->_sub_render_where($kind));
             }
         }
+
+        return null;
     }
 
-    protected function _render_andwhere()
+    protected function _render_andwhere(): ?string
     {
         if (isset($this->args['where']) && isset($this->args['having'])) {
             throw new Exception('Mixing of WHERE and HAVING conditions not allowed in query expression');
@@ -775,12 +775,14 @@ class Query extends Expression
                 return implode(' and ', $this->_sub_render_where($kind));
             }
         }
+
+        return null;
     }
 
-    protected function _render_having()
+    protected function _render_having(): ?string
     {
         if (!isset($this->args['having'])) {
-            return;
+            return null;
         }
 
         return ' having ' . implode(' and ', $this->_sub_render_where('having'));
@@ -818,7 +820,7 @@ class Query extends Expression
         return $this;
     }
 
-    protected function _render_group()
+    protected function _render_group(): ?string
     {
         if (!isset($this->args['group'])) {
             return '';
@@ -838,8 +840,8 @@ class Query extends Expression
     /**
      * Sets field value for INSERT or UPDATE statements.
      *
-     * @param string|array $field Name of the field
-     * @param mixed        $value Value of the field
+     * @param string|Expression|Expressionable|array $field Name of the field
+     * @param mixed                                  $value Value of the field
      *
      * @return $this
      */
@@ -869,7 +871,7 @@ class Query extends Expression
         return $this;
     }
 
-    protected function _render_set()
+    protected function _render_set(): ?string
     {
         // will be joined for output
         $ret = [];
@@ -886,7 +888,7 @@ class Query extends Expression
         return implode(', ', $ret);
     }
 
-    protected function _render_set_fields()
+    protected function _render_set_fields(): ?string
     {
         // will be joined for output
         $ret = [];
@@ -902,7 +904,7 @@ class Query extends Expression
         return implode(', ', $ret);
     }
 
-    protected function _render_set_values()
+    protected function _render_set_values(): ?string
     {
         // will be joined for output
         $ret = [];
@@ -950,7 +952,7 @@ class Query extends Expression
         return $this;
     }
 
-    protected function _render_option()
+    protected function _render_option(): ?string
     {
         if (!isset($this->args['option'][$this->mode])) {
             return '';
@@ -1045,14 +1047,16 @@ class Query extends Expression
         return $this;
     }
 
-    public function _render_limit()
+    public function _render_limit(): ?string
     {
-        if (isset($this->args['limit'])) {
-            return ' limit ' .
-                (int) $this->args['limit']['shift'] .
-                ', ' .
-                (int) $this->args['limit']['cnt'];
+        if (!isset($this->args['limit'])) {
+            return null;
         }
+
+        return ' limit ' .
+            (int) $this->args['limit']['shift'] .
+            ', ' .
+            (int) $this->args['limit']['cnt'];
     }
 
     // }}}
@@ -1116,7 +1120,7 @@ class Query extends Expression
         return $this;
     }
 
-    public function _render_order()
+    public function _render_order(): ?string
     {
         if (!isset($this->args['order'])) {
             return '';
@@ -1147,7 +1151,7 @@ class Query extends Expression
 
     // }}}
 
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         $arr = [
             'R' => false,
@@ -1173,7 +1177,7 @@ class Query extends Expression
     /**
      * Renders query template. If the template is not explicitly set will use "select" mode.
      */
-    public function render()
+    public function render(): string
     {
         if (!$this->template) {
             $this->mode('select');
@@ -1340,10 +1344,10 @@ class Query extends Expression
         return $this;
     }
 
-    protected function _render_case()
+    protected function _render_case(): ?string
     {
         if (!isset($this->args['case_when'])) {
-            return;
+            return null;
         }
 
         $ret = '';
@@ -1391,7 +1395,7 @@ class Query extends Expression
      * @param string|null $alias Alias name
      * @param mixed       $value Value to set in args array
      */
-    protected function _set_args($what, $alias, $value)
+    protected function _set_args($what, $alias, $value): void
     {
         // save value in args
         if ($alias === null) {

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -69,7 +69,7 @@ class ConnectionTest extends AtkPhpunit\TestCase
     /**
      * Test constructor.
      */
-    public function testInit()
+    public function testInit(): void
     {
         $c = Connection::connect('sqlite::memory:');
         $this->assertSame(
@@ -81,7 +81,7 @@ class ConnectionTest extends AtkPhpunit\TestCase
     /**
      * Test DSN normalize.
      */
-    public function testDsnNormalize()
+    public function testDsnNormalize(): void
     {
         // standard
         $dsn = Connection::normalizeDsn('mysql://root:pass@localhost/db');
@@ -119,7 +119,7 @@ class ConnectionTest extends AtkPhpunit\TestCase
         $this->assertSame(['dsn' => 'mysql:host=localhost:1234;dbname=db', 'user' => null, 'pass' => null, 'driverSchema' => 'mysql', 'rest' => 'host=localhost:1234;dbname=db'], $dsn);
     }
 
-    public function testConnectionRegistry()
+    public function testConnectionRegistry(): void
     {
         DummyConnection::registerConnectionClass();
 
@@ -137,31 +137,31 @@ class ConnectionTest extends AtkPhpunit\TestCase
         $this->assertSame(DummyConnection4::class, Connection::resolveConnectionClass('dummy4'));
     }
 
-    public function testMysqlFail()
+    public function testMysqlFail(): void
     {
         $this->expectException(\Exception::class);
         $c = Connection::connect('mysql:host=256.256.256.256'); // invalid host
     }
 
-    public function testException1()
+    public function testException1(): void
     {
         $this->expectException(\Atk4\Dsql\Exception::class);
         $c = \Atk4\Dsql\Sqlite\Connection::connect(':');
     }
 
-    public function testException2()
+    public function testException2(): void
     {
         $this->expectException(\Atk4\Dsql\Exception::class);
         $c = Connection::connect('');
     }
 
-    public function testException3()
+    public function testException3(): void
     {
         $this->expectException(\Atk4\Dsql\Exception::class);
         $c = new \Atk4\Dsql\Sqlite\Connection('sqlite::memory'); // @phpstan-ignore-line
     }
 
-    public function testException4()
+    public function testException4(): void
     {
         $c = new \Atk4\Dsql\Sqlite\Connection();
         $q = $c->expr('select (2+2)');

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -66,9 +66,6 @@ class DummyConnection4 extends Connection
  */
 class ConnectionTest extends AtkPhpunit\TestCase
 {
-    /**
-     * Test constructor.
-     */
     public function testInit(): void
     {
         $c = Connection::connect('sqlite::memory:');

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -13,8 +13,6 @@ use Atk4\Dsql\Expression;
 class ExceptionTest extends AtkPhpunit\TestCase
 {
     /**
-     * Test constructor.
-     *
      * @covers ::__construct
      */
     public function testException1(): void

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -17,21 +17,21 @@ class ExceptionTest extends AtkPhpunit\TestCase
      *
      * @covers ::__construct
      */
-    public function testException1()
+    public function testException1(): void
     {
         $this->expectException(\Atk4\Dsql\Exception::class);
 
         throw new \Atk4\Dsql\Exception();
     }
 
-    public function testException2()
+    public function testException2(): void
     {
         $this->expectException(\Atk4\Dsql\Exception::class);
         $e = new Expression('hello, [world]');
         $e->render();
     }
 
-    public function testException3()
+    public function testException3(): void
     {
         try {
             $e = new Expression('hello, [world]');

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -15,7 +15,10 @@ use Atk4\Dsql\Query;
  */
 class ExpressionTest extends AtkPhpunit\TestCase
 {
-    public function e(...$args)
+    /**
+     * @param mixed ...$args
+     */
+    public function e(...$args): Expression
     {
         return new Expression(...$args);
     }
@@ -195,7 +198,10 @@ class ExpressionTest extends AtkPhpunit\TestCase
         $this->assertSame($expectedStr, $this->e($exprStr, $exprArgs)->render());
     }
 
-    public function provideNoTemplatingInSqlStringData()
+    /**
+     * @return iterable<array>
+     */
+    public function provideNoTemplatingInSqlStringData(): iterable
     {
         $testStrs = [];
         foreach (['\'', '"', '`'] as $enclosureChar) {
@@ -296,7 +302,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
     public function testExpr(): void
     {
         $e = $this->e(['connection' => new \stdClass()]);
-        $this->assertTrue($e->expr()->connection instanceof \stdClass);
+        $this->assertInstanceOf(\stdClass::class, $e->expr()->connection);
     }
 
     /**
@@ -480,7 +486,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      */
     public function testIteratorAggregate(): void
     {
-        // todo - can not test this without actual DB connection and executing expression
+        // TODO can not test this without actual DB connection and executing expression
     }
 
     /**
@@ -500,15 +506,6 @@ class ExpressionTest extends AtkPhpunit\TestCase
             [],
             $e->params
         );
-    }
-
-    /**
-     * Test reset exception if tag is not a string.
-     */
-    public function testResetException(): void
-    {
-        $this->expectException(Exception::class);
-        $this->e('test')->reset($this->e());
     }
 
     /**

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -8,6 +8,7 @@ use Atk4\Core\AtkPhpunit;
 use Atk4\Dsql\Exception;
 use Atk4\Dsql\Expression;
 use Atk4\Dsql\Expressionable;
+use Atk4\Dsql\Mysql;
 use Atk4\Dsql\Query;
 
 /**
@@ -301,8 +302,8 @@ class ExpressionTest extends AtkPhpunit\TestCase
      */
     public function testExpr(): void
     {
-        $e = $this->e(['connection' => new \stdClass()]);
-        $this->assertInstanceOf(\stdClass::class, $e->expr()->connection);
+        $e = $this->e(['connection' => new Mysql\Connection()]);
+        $this->assertInstanceOf(Mysql\Connection::class, $e->expr()->connection);
     }
 
     /**

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -25,7 +25,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::__construct
      */
-    public function testConstructorException1st1()
+    public function testConstructorException1st1(): void
     {
         $this->expectException(Exception::class);
         $this->e(null);
@@ -36,7 +36,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::__construct
      */
-    public function testConstructorException1st2()
+    public function testConstructorException1st2(): void
     {
         $this->expectException(Exception::class);
         $this->e(false);
@@ -45,7 +45,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
     /**
      * Test constructor exception - wrong 2nd parameter.
      */
-    public function testConstructorException2nd1()
+    public function testConstructorException2nd1(): void
     {
         $this->expectException(Exception::class);
         $this->e('hello, []', false);
@@ -54,7 +54,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
     /**
      * Test constructor exception - wrong 2nd parameter.
      */
-    public function testConstructorException2nd2()
+    public function testConstructorException2nd2(): void
     {
         $this->expectException(Exception::class);
         $this->e('hello, []', 'hello');
@@ -63,7 +63,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
     /**
      * Test constructor exception - no arguments.
      */
-    public function testConstructorException0arg()
+    public function testConstructorException0arg(): void
     {
         // Template is not defined for Expression
         $this->expectException(Exception::class);
@@ -75,7 +75,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::__construct
      */
-    public function testConstructor1()
+    public function testConstructor1(): void
     {
         $this->assertSame(
             '',
@@ -90,7 +90,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      * @covers ::__construct
      * @covers ::escapeIdentifier
      */
-    public function testConstructor2()
+    public function testConstructor2(): void
     {
         // pass as string
         $this->assertSame(
@@ -124,7 +124,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::__construct
      */
-    public function testConstructor3()
+    public function testConstructor3(): void
     {
         $e = $this->e('hello, [who]', ['who' => 'world']);
         $this->assertSame('hello, :a', $e->render());
@@ -140,7 +140,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::__construct
      */
-    public function testConstructor4()
+    public function testConstructor4(): void
     {
         // argument = Expression
         $this->assertSame(
@@ -190,7 +190,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
     /**
      * @dataProvider provideNoTemplatingInSqlStringData
      */
-    public function testNoTemplatingInSqlString(string $expectedStr, string $exprStr, array $exprArgs)
+    public function testNoTemplatingInSqlString(string $expectedStr, string $exprStr, array $exprArgs): void
     {
         $this->assertSame($expectedStr, $this->e($exprStr, $exprArgs)->render());
     }
@@ -235,7 +235,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      * @covers ::escapeParam
      * @covers ::getDebugQuery
      */
-    public function testNestedParams()
+    public function testNestedParams(): void
     {
         // ++1 and --2
         $e1 = $this->e('[] and []', [
@@ -258,7 +258,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      * @covers ::__construct
      * @covers ::render
      */
-    public function testNestedExpressions()
+    public function testNestedExpressions(): void
     {
         $e1 = $this->e('Hello [who]', ['who' => 'world']);
 
@@ -280,7 +280,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      * @covers ::__toString
      */
     /*
-    public function testToStringException1()
+    public function testToStringException1(): void
     {
         $e = new MyBadExpression('Hello');
         $this->expectException(Exception::class);
@@ -293,7 +293,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::expr
      */
-    public function testExpr()
+    public function testExpr(): void
     {
         $e = $this->e(['connection' => new \stdClass()]);
         $this->assertTrue($e->expr()->connection instanceof \stdClass);
@@ -306,7 +306,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      * @covers ::escapeIdentifier
      * @covers ::escapeIdentifierSoft
      */
-    public function testEscape()
+    public function testEscape(): void
     {
         // escaping expressions
         $this->assertSame(
@@ -367,7 +367,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::escapeParam
      */
-    public function testParam()
+    public function testParam(): void
     {
         $e = new Expression('hello, [who]', ['who' => 'world']);
         $this->assertSame(
@@ -383,7 +383,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
     /**
      * @covers ::consume
      */
-    public function testConsume()
+    public function testConsume(): void
     {
         $constants = (new \ReflectionClass(Expression::class))->getConstants();
 
@@ -416,7 +416,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::consume
      */
-    public function testConsumeException1()
+    public function testConsumeException1(): void
     {
         $this->expectException(Exception::class);
         $this->callProtected($this->e(), 'consume', 123, 'blahblah');
@@ -427,7 +427,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::consume
      */
-    public function testConsumeException2()
+    public function testConsumeException2(): void
     {
         $this->expectException(Exception::class);
         $this->callProtected($this->e(), 'consume', new \StdClass());
@@ -439,7 +439,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      * @covers ::offsetSet
      * @covers ::offsetUnset
      */
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $e = $this->e('', ['parrot' => 'red', 'blue']);
 
@@ -478,7 +478,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @doesNotPerformAssertions
      */
-    public function testIteratorAggregate()
+    public function testIteratorAggregate(): void
     {
         // todo - can not test this without actual DB connection and executing expression
     }
@@ -488,7 +488,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @coversNothing
      */
-    public function testJsonExpression()
+    public function testJsonExpression(): void
     {
         $e = new JsonExpression('hello, [who]', ['who' => 'world']);
 
@@ -505,7 +505,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
     /**
      * Test reset exception if tag is not a string.
      */
-    public function testResetException()
+    public function testResetException(): void
     {
         $this->expectException(Exception::class);
         $this->e('test')->reset($this->e());
@@ -518,7 +518,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @doesNotPerformAssertions
      */
-    public function testVarDump()
+    public function testVarDump(): void
     {
         $this->e('test')->__debugInfo();
 
@@ -530,7 +530,7 @@ class ExpressionTest extends AtkPhpunit\TestCase
      *
      * @covers ::reset
      */
-    public function testReset()
+    public function testReset(): void
     {
         // reset everything
         $e = $this->e('hello, [name] [surname]', ['name' => 'John', 'surname' => 'Doe']);

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -71,11 +71,11 @@ class QueryTest extends AtkPhpunit\TestCase
             $this->callProtected($this->q()->field('first_name'), '_render_field')
         );
         $this->assertSame(
-            '"first_name","last_name"',
+            '"first_name", "last_name"',
             $this->callProtected($this->q()->field('first_name,last_name'), '_render_field')
         );
         $this->assertSame(
-            '"first_name","last_name"',
+            '"first_name", "last_name"',
             $this->callProtected($this->q()->field('first_name')->field('last_name'), '_render_field')
         );
         $this->assertSame(
@@ -447,31 +447,31 @@ class QueryTest extends AtkPhpunit\TestCase
 
         // multiple tables
         $this->assertSame(
-            'select "employee"."name" from "employee","jobs"',
+            'select "employee"."name" from "employee", "jobs"',
             $this->q()
                 ->field('employee.name')->table('employee')->table('jobs')
                 ->render()
         );
         $this->assertSame(
-            'select "name" from "employee","jobs"',
+            'select "name" from "employee", "jobs"',
             $this->q()
                 ->field('name')->table('employee,jobs')
                 ->render()
         );
         $this->assertSame(
-            'select "name" from "employee","jobs"',
+            'select "name" from "employee", "jobs"',
             $this->q()
                 ->field('name')->table('  employee ,   jobs  ')
                 ->render()
         );
         $this->assertSame(
-            'select "name" from "employee","jobs"',
+            'select "name" from "employee", "jobs"',
             $this->q()
                 ->field('name')->table(['employee', 'jobs'])
                 ->render()
         );
         $this->assertSame(
-            'select "name" from "employee","jobs"',
+            'select "name" from "employee", "jobs"',
             $this->q()
                 ->field('name')->table(['employee  ', '  jobs'])
                 ->render()
@@ -479,13 +479,13 @@ class QueryTest extends AtkPhpunit\TestCase
 
         // multiple tables with aliases
         $this->assertSame(
-            'select "name" from "employee","jobs" "j"',
+            'select "name" from "employee", "jobs" "j"',
             $this->q()
                 ->field('name')->table(['employee', 'j' => 'jobs'])
                 ->render()
         );
         $this->assertSame(
-            'select "name" from "employee" "e","jobs" "j"',
+            'select "name" from "employee" "e", "jobs" "j"',
             $this->q()
                 ->field('name')->table(['e' => 'employee', 'j' => 'jobs'])
                 ->render()
@@ -535,8 +535,9 @@ class QueryTest extends AtkPhpunit\TestCase
         $q2 = $this->q()->table('customer');
 
         $this->assertSame(
-            //this way it would be more correct: 'select "e"."name","c"."name" from (select * from "employee") "e",(select * from "customer") "c" where "e"."last_name" = "c"."last_name"',
-            'select "e"."name","c"."name" from (select * from "employee") "e",(select * from "customer") "c" where "e"."last_name" = c.last_name',
+            // TODO this way it would be more correct:
+            // 'select "e"."name", "c"."name" from (select * from "employee") "e", (select * from "customer") "c" where "e"."last_name" = "c"."last_name"',
+            'select "e"."name", "c"."name" from (select * from "employee") "e", (select * from "customer") "c" where "e"."last_name" = c.last_name',
             $this->q()
                 ->field('e.name')
                 ->field('c.name')
@@ -648,7 +649,7 @@ class QueryTest extends AtkPhpunit\TestCase
             ->field('amount', 'debit')
             ->field($this->q()->expr('0'), 'credit'); // simply 0
         $this->assertSame(
-            'select "date","amount" "debit",0 "credit" from "sales"',
+            'select "date", "amount" "debit", 0 "credit" from "sales"',
             $q1->render()
         );
 
@@ -659,23 +660,23 @@ class QueryTest extends AtkPhpunit\TestCase
             ->field($this->q()->expr('0'), 'debit') // simply 0
             ->field('amount', 'credit');
         $this->assertSame(
-            'select "date",0 "debit","amount" "credit" from "purchases"',
+            'select "date", 0 "debit", "amount" "credit" from "purchases"',
             $q2->render()
         );
 
         // $q1 union $q2
         $u = new Expression('([] union [])', [$q1, $q2]);
         $this->assertSame(
-            '((select "date","amount" "debit",0 "credit" from "sales") union (select "date",0 "debit","amount" "credit" from "purchases"))',
+            '((select "date", "amount" "debit", 0 "credit" from "sales") union (select "date", 0 "debit", "amount" "credit" from "purchases"))',
             $u->render()
         );
 
-        // SELECT date,debit,credit FROM ($q1 union $q2)
+        // SELECT date, debit, credit FROM ($q1 union $q2)
         $q = $this->q()
             ->field('date,debit,credit')
             ->table($u, 'derrivedTable');
         $this->assertSame(
-            'select "date","debit","credit" from ((select "date","amount" "debit",0 "credit" from "sales") union (select "date",0 "debit","amount" "credit" from "purchases")) "derrivedTable"',
+            'select "date", "debit", "credit" from ((select "date", "amount" "debit", 0 "credit" from "sales") union (select "date", 0 "debit", "amount" "credit" from "purchases")) "derrivedTable"',
             $q->render()
         );
 
@@ -686,16 +687,16 @@ class QueryTest extends AtkPhpunit\TestCase
         $q2->wrapInParentheses = false;
         $u = new Expression('([] union [])', [$q1, $q2]);
         $this->assertSame(
-            '(select "date","amount" "debit",0 "credit" from "sales" union select "date",0 "debit","amount" "credit" from "purchases")',
+            '(select "date", "amount" "debit", 0 "credit" from "sales" union select "date", 0 "debit", "amount" "credit" from "purchases")',
             $u->render()
         );
 
-        // SELECT date,debit,credit FROM ($q1 union $q2)
+        // SELECT date, debit, credit FROM ($q1 union $q2)
         $q = $this->q()
             ->field('date,debit,credit')
             ->table($u, 'derrivedTable');
         $this->assertSame(
-            'select "date","debit","credit" from (select "date","amount" "debit",0 "credit" from "sales" union select "date",0 "debit","amount" "credit" from "purchases") "derrivedTable"',
+            'select "date", "debit", "credit" from (select "date", "amount" "debit", 0 "credit" from "sales" union select "date", 0 "debit", "amount" "credit" from "purchases") "derrivedTable"',
             $q->render()
         );
     }
@@ -777,11 +778,11 @@ class QueryTest extends AtkPhpunit\TestCase
             $this->q('[where]')->where('id', '=', 1)->render()
         );
         $this->assertSame(
-            'where "id" in (:a,:b)',
+            'where "id" in (:a, :b)',
             $this->q('[where]')->where('id', '=', [1, 2])->render()
         );
         $this->assertSame(
-            'where "id" in (:a,:b)',
+            'where "id" in (:a, :b)',
             $this->q('[where]')->where('id', [1, 2])->render()
         );
         $this->assertSame(
@@ -874,27 +875,27 @@ class QueryTest extends AtkPhpunit\TestCase
     {
         // in | not in
         $this->assertSame(
-            'where "id" in (:a,:b)',
+            'where "id" in (:a, :b)',
             $this->q('[where]')->where('id', 'in', [1, 2])->render()
         );
         $this->assertSame(
-            'where "id" not in (:a,:b)',
+            'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id', 'not in', [1, 2])->render()
         );
         $this->assertSame(
-            'where "id" not in (:a,:b)',
+            'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id', 'not', [1, 2])->render()
         );
         $this->assertSame(
-            'where "id" in (:a,:b)',
+            'where "id" in (:a, :b)',
             $this->q('[where]')->where('id', '=', [1, 2])->render()
         );
         $this->assertSame(
-            'where "id" not in (:a,:b)',
+            'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id', '<>', [1, 2])->render()
         );
         $this->assertSame(
-            'where "id" not in (:a,:b)',
+            'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id', '!=', [1, 2])->render()
         );
         // speacial treatment for empty array values
@@ -908,15 +909,15 @@ class QueryTest extends AtkPhpunit\TestCase
         );
         // pass array as CSV
         $this->assertSame(
-            'where "id" in (:a,:b)',
+            'where "id" in (:a, :b)',
             $this->q('[where]')->where('id', 'in', '1,2')->render()
         );
         $this->assertSame(
-            'where "id" not in (:a,:b)',
+            'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id', 'not in', '1,    2')->render()
         );
         $this->assertSame(
-            'where "id" not in (:a,:b)',
+            'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id', 'not', '1,2')->render()
         );
 
@@ -973,15 +974,15 @@ class QueryTest extends AtkPhpunit\TestCase
 
         // in | not in
         $this->assertSame(
-            'where "id" in (:a,:b)',
+            'where "id" in (:a, :b)',
             $this->q('[where]')->where('id=', [1, 2])->render()
         );
         $this->assertSame(
-            'where "id" not in (:a,:b)',
+            'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id!=', [1, 2])->render()
         );
         $this->assertSame(
-            'where "id" not in (:a,:b)',
+            'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id<>', [1, 2])->render()
         );
     }
@@ -1409,7 +1410,7 @@ class QueryTest extends AtkPhpunit\TestCase
 
         // set multiple fields
         $this->assertSame(
-            'insert into "employee" ("time","name") values (now(),:a)',
+            'insert into "employee" ("time", "name") values (now(), :a)',
             $this->q()
                 ->field('time')->field('name')->table('employee')
                 ->set('time', new Expression('now()'))
@@ -1420,7 +1421,7 @@ class QueryTest extends AtkPhpunit\TestCase
 
         // set as array
         $this->assertSame(
-            'insert into "employee" ("time","name") values (now(),:a)',
+            'insert into "employee" ("time", "name") values (now(), :a)',
             $this->q()
                 ->field('time')->field('name')->table('employee')
                 ->set(['time' => new Expression('now()'), 'name' => 'unknown'])
@@ -1763,7 +1764,7 @@ class QueryTest extends AtkPhpunit\TestCase
             ->with($q1, 'q12', ['bar', 'baz'], true) // this one is recursive
             ->table('q11')
             ->table('q12');
-        $this->assertSame('with recursive "q11" ("foo","qwe""ry") as (select "salary" from "salaries"),"q12" ("bar","baz") as (select "salary" from "salaries") select * from "q11","q12"', $q2->render());
+        $this->assertSame('with recursive "q11" ("foo", "qwe""ry") as (select "salary" from "salaries"), "q12" ("bar", "baz") as (select "salary" from "salaries") select * from "q11", "q12"', $q2->render());
 
         // now test some more useful reql life query
         $quotes = $this->q()
@@ -1785,9 +1786,9 @@ class QueryTest extends AtkPhpunit\TestCase
             ->field(['name', 'salary', 'q.quoted', 'i.invoiced']);
         $this->assertSame(
             'with ' .
-                '"q" ("emp","quoted") as (select "emp_id",sum(:a) from "quotes" group by "emp_id"),' .
-                '"i" ("emp","invoiced") as (select "emp_id",sum(:b) from "invoices" group by "emp_id") ' .
-            'select "name","salary","q"."quoted","i"."invoiced" ' .
+                '"q" ("emp", "quoted") as (select "emp_id", sum(:a) from "quotes" group by "emp_id"), ' .
+                '"i" ("emp", "invoiced") as (select "emp_id", sum(:b) from "invoices" group by "emp_id") ' .
+            'select "name", "salary", "q"."quoted", "i"."invoiced" ' .
             'from "employees" ' .
                 'left join "q" on "q"."emp" = "employees"."id" ' .
                 'left join "i" on "i"."emp" = "employees"."id"',

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -25,8 +25,6 @@ class QueryTest extends AtkPhpunit\TestCase
     }
 
     /**
-     * Test constructor.
-     *
      * @covers ::__construct
      */
     public function testConstruct(): void

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -29,7 +29,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::__construct
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         // passing properties in constructor
         $this->assertSame(
@@ -43,7 +43,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::dsql
      */
-    public function testDsql()
+    public function testDsql(): void
     {
         $q = $this->q(['connection' => new \stdClass()]);
         $this->assertTrue($q->dsql()->connection instanceof \stdClass);
@@ -54,7 +54,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::field
      */
-    public function testFieldReturnValue()
+    public function testFieldReturnValue(): void
     {
         $q = $this->q();
         $this->assertSame($q, $q->field('first_name'));
@@ -66,7 +66,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_field
      * @covers ::field
      */
-    public function testFieldBasic()
+    public function testFieldBasic(): void
     {
         $this->assertSame(
             '"first_name"',
@@ -128,7 +128,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_field
      * @covers ::field
      */
-    public function testFieldDefaultField()
+    public function testFieldDefaultField(): void
     {
         // default defaultField
         $this->assertSame(
@@ -158,7 +158,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_field
      * @covers ::field
      */
-    public function testFieldExpression()
+    public function testFieldExpression(): void
     {
         $this->assertSame(
             '"name"',
@@ -201,7 +201,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_set_args
      * @covers ::field
      */
-    public function testFieldException1()
+    public function testFieldException1(): void
     {
         $this->expectException(Exception::class);
         $this->q()->field('name', 'a')->field('surname', 'a');
@@ -212,7 +212,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::field
      */
-    public function testFieldException2()
+    public function testFieldException2(): void
     {
         $this->expectException(Exception::class);
         $this->q()->field(['name', 'surname'], 'a');
@@ -223,7 +223,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::table
      */
-    public function testTableException1()
+    public function testTableException1(): void
     {
         $this->expectException(Exception::class);
         $this->q()->table('employee,jobs', 'u');
@@ -234,7 +234,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::table
      */
-    public function testTableException2()
+    public function testTableException2(): void
     {
         $this->expectException(Exception::class);
         $this->q()->table(['employee', 'jobs'], 'u');
@@ -247,7 +247,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @doesNotPerformAssertions
      */
-    public function testTableException3()
+    public function testTableException3(): void
     {
         //$this->expectException(Exception::class); // no more
         $this->q()->table($this->q()->expr('test'));
@@ -258,7 +258,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::table
      */
-    public function testTableException4()
+    public function testTableException4(): void
     {
         $this->expectException(Exception::class);
         $this->q()->table($this->q()->table('test'));
@@ -270,7 +270,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_set_args
      * @covers ::table
      */
-    public function testTableException5()
+    public function testTableException5(): void
     {
         $this->expectException(Exception::class);
         $this->q()
@@ -284,7 +284,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_set_args
      * @covers ::table
      */
-    public function testTableException6()
+    public function testTableException6(): void
     {
         $this->expectException(Exception::class);
         $this->q()
@@ -298,7 +298,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_set_args
      * @covers ::table
      */
-    public function testTableException7()
+    public function testTableException7(): void
     {
         $this->expectException(Exception::class);
         $this->q()
@@ -312,7 +312,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_set_args
      * @covers ::table
      */
-    public function testTableException8()
+    public function testTableException8(): void
     {
         $this->expectException(Exception::class);
         $this->q()
@@ -326,7 +326,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_set_args
      * @covers ::table
      */
-    public function testTableException9()
+    public function testTableException9(): void
     {
         $this->expectException(Exception::class);
         $this->q()
@@ -339,7 +339,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::table
      */
-    public function testTableException10()
+    public function testTableException10(): void
     {
         $this->expectException(Exception::class);
         $this->q()
@@ -354,7 +354,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::table
      */
-    public function testTableException11()
+    public function testTableException11(): void
     {
         $this->expectException(Exception::class);
         $this->q()
@@ -369,7 +369,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::mode
      */
-    public function testModeException1()
+    public function testModeException1(): void
     {
         $this->expectException(Exception::class);
         $this->q()->mode('non_existant_mode');
@@ -380,7 +380,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::table
      */
-    public function testTableReturnValue()
+    public function testTableReturnValue(): void
     {
         $q = $this->q();
         $this->assertSame($q, $q->table('employee'));
@@ -391,7 +391,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_table_noalias
      * @covers ::table
      */
-    public function testTableRender1()
+    public function testTableRender1(): void
     {
         // no table defined
         $this->assertSame(
@@ -513,7 +513,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_table
      * @covers ::table
      */
-    public function testTableRender2()
+    public function testTableRender2(): void
     {
         // pass table as expression or query
         $q = $this->q()->table('employee');
@@ -554,7 +554,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers \Atk4\Dsql\Expression::consume
      * @covers \Atk4\Dsql\Expression::render
      */
-    public function testBasicRenderSubquery()
+    public function testBasicRenderSubquery(): void
     {
         $age = new Expression('coalesce([age], [default_age])');
         $age['age'] = new Expression('year(now()) - year(birth_date)');
@@ -571,7 +571,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * @covers \Atk4\Dsql\Expression::getDebugQuery
      */
-    public function testTestgetDebugQuery()
+    public function testTestgetDebugQuery(): void
     {
         $age = new Expression('coalesce([age], [default_age], [foo], [bar])');
         $age['age'] = new Expression('year(now()) - year(birth_date)');
@@ -590,7 +590,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * @covers ::__debugInfo
      */
-    public function testVarDump()
+    public function testVarDump(): void
     {
         $this->assertMatchesRegularExpression(
             '/select\s+\*\s+from\s*"user".*/',
@@ -601,7 +601,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * @covers ::__debugInfo
      */
-    public function testVarDump2()
+    public function testVarDump2(): void
     {
         $this->assertMatchesRegularExpression(
             '/.*Expression could not render tag.*/',
@@ -612,7 +612,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * @covers ::__debugInfo
      */
-    public function testVarDump3()
+    public function testVarDump3(): void
     {
         $this->assertMatchesRegularExpression(
             '/.*Hello \'php\'.*/',
@@ -623,7 +623,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * @covers ::__debugInfo
      */
-    public function testVarDump4()
+    public function testVarDump4(): void
     {
         // should throw exception "Table cannot be Query in UPDATE, INSERT etc. query modes"
         $this->assertMatchesRegularExpression(
@@ -641,7 +641,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::render
      * @covers ::table
      */
-    public function testUnionQuery()
+    public function testUnionQuery(): void
     {
         // 1st query
         $q1 = $this->q()
@@ -707,7 +707,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::where
      */
-    public function testWhereReturnValue()
+    public function testWhereReturnValue(): void
     {
         $q = $this->q();
         $this->assertSame($q, $q->where('id', 1));
@@ -718,7 +718,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::field
      */
-    public function testHavingReturnValue()
+    public function testHavingReturnValue(): void
     {
         $q = $this->q();
         $this->assertSame($q, $q->having('id', 1));
@@ -731,7 +731,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_sub_render_where
      * @covers ::where
      */
-    public function testWhereBasic()
+    public function testWhereBasic(): void
     {
         // one parameter as a string - treat as expression
         $this->assertSame(
@@ -824,7 +824,7 @@ class QueryTest extends AtkPhpunit\TestCase
         );
     }
 
-    public function testWhereExpression()
+    public function testWhereExpression(): void
     {
         $this->assertSame(
             'where (a = 5 or b = 6) and (c = 3 or d = 1)',
@@ -837,7 +837,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::order
      */
-    public function testWhereIncompatibleObject1()
+    public function testWhereIncompatibleObject1(): void
     {
         $this->expectException(Exception::class);
         $this->q('[where]')->where('a', new \DateTime())->render();
@@ -848,7 +848,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::order
      */
-    public function testWhereIncompatibleObject2()
+    public function testWhereIncompatibleObject2(): void
     {
         $this->expectException(Exception::class);
         $this->q('[where]')->where('a', new \DateTime());
@@ -859,7 +859,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::order
      */
-    public function testWhereIncompatibleObject3()
+    public function testWhereIncompatibleObject3(): void
     {
         $this->expectException(Exception::class);
         $this->q('[where]')->where('a', '<>', new \DateTime());
@@ -872,7 +872,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_sub_render_where
      * @covers ::where
      */
-    public function testWhereSpecialValues()
+    public function testWhereSpecialValues(): void
     {
         // in | not in
         $this->assertSame(
@@ -994,7 +994,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_having
      * @covers ::having
      */
-    public function testBasicHaving()
+    public function testBasicHaving(): void
     {
         $this->assertSame(
             'having "id" = :a',
@@ -1016,7 +1016,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_limit
      * @covers ::limit
      */
-    public function testLimit()
+    public function testLimit(): void
     {
         $this->assertSame(
             'limit 0, 100',
@@ -1034,7 +1034,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_order
      * @covers ::order
      */
-    public function testOrder()
+    public function testOrder(): void
     {
         $this->assertSame(
             'order by "name"',
@@ -1118,7 +1118,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::order
      */
-    public function testOrderException1()
+    public function testOrderException1(): void
     {
         $this->expectException(Exception::class);
         $this->q('[order]')->order(['name', 'surname'], 'desc');
@@ -1130,7 +1130,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_group
      * @covers ::group
      */
-    public function testGroup()
+    public function testGroup(): void
     {
         $this->assertSame(
             'group by "gender"',
@@ -1183,7 +1183,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * Test groupConcat.
      */
-    public function testGroupConcatException()
+    public function testGroupConcatException(): void
     {
         // doesn't support groupConcat by default
         $this->expectException(Exception::class);
@@ -1195,7 +1195,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::groupConcat
      */
-    public function testGroupConcat()
+    public function testGroupConcat(): void
     {
         $q = new Mysql\Query();
         $this->assertSame('group_concat(`foo` separator :a)', $q->groupConcat('foo', '-')->render());
@@ -1218,7 +1218,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::expr
      */
-    public function testExpr()
+    public function testExpr(): void
     {
         $this->assertSame(Expression::class, get_class($this->q()->expr('foo')));
 
@@ -1232,7 +1232,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_join
      * @covers ::join
      */
-    public function testJoin()
+    public function testJoin(): void
     {
         $this->assertSame(
             'left join "address" on "address"."id" = "address_id"',
@@ -1293,7 +1293,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::mode
      * @covers ::where
      */
-    public function testCombinedWhere()
+    public function testCombinedWhere(): void
     {
         $this->assertSame(
             'select "name" from "employee" where "a" = :a',
@@ -1349,7 +1349,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::orExpr
      * @covers ::where
      */
-    public function testEmptyOrAndWhere()
+    public function testEmptyOrAndWhere(): void
     {
         $this->assertSame(
             '',
@@ -1372,7 +1372,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::set
      * @covers ::where
      */
-    public function testInsertDeleteUpdate()
+    public function testInsertDeleteUpdate(): void
     {
         // delete template
         $this->assertSame(
@@ -1436,7 +1436,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::set
      */
-    public function testSetReturnValue()
+    public function testSetReturnValue(): void
     {
         $q = $this->q();
         $this->assertSame($q, $q->set('id', 1));
@@ -1447,7 +1447,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::set
      */
-    public function testSetException1()
+    public function testSetException1(): void
     {
         $this->expectException(Exception::class);
         $this->q()->set('name', []);
@@ -1460,7 +1460,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @doesNotPerformAssertions
      */
-    public function testSetException2()
+    public function testSetException2(): void
     {
         $this->q()->set((new Expression('foo')), 1);
     }
@@ -1474,7 +1474,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::orExpr
      * @covers ::where
      */
-    public function testNestedOrAnd()
+    public function testNestedOrAnd(): void
     {
         // test 1
         $q = $this->q();
@@ -1510,7 +1510,7 @@ class QueryTest extends AtkPhpunit\TestCase
         );
     }
 
-    public function testNestedOrAndHaving()
+    public function testNestedOrAndHaving(): void
     {
         $q = $this->q();
         $q->table('employee')->field(new Expression('sum([])', ['amount']), 'salary')->group('type');
@@ -1526,7 +1526,7 @@ class QueryTest extends AtkPhpunit\TestCase
         );
     }
 
-    public function testNestedOrAndHavingWithWhereException()
+    public function testNestedOrAndHavingWithWhereException(): void
     {
         $q = $this->q();
         $q->table('employee')->field(new Expression('sum([])', ['amount']), 'salary')->group('type');
@@ -1546,7 +1546,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers \Atk4\Dsql\Expression::reset
      */
-    public function testReset()
+    public function testReset(): void
     {
         // reset everything
         $q = $this->q()->table('user')->where('name', 'John');
@@ -1568,7 +1568,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::_render_option
      * @covers ::option
      */
-    public function testOption()
+    public function testOption(): void
     {
         // single option
         $this->assertSame(
@@ -1614,7 +1614,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::otherwise
      * @covers ::when
      */
-    public function testCaseExprNormal()
+    public function testCaseExprNormal(): void
     {
         // Test normal form
         $s = $this->q()->caseExpr()
@@ -1643,7 +1643,7 @@ class QueryTest extends AtkPhpunit\TestCase
      * @covers ::otherwise
      * @covers ::when
      */
-    public function testCaseExprShortForm()
+    public function testCaseExprShortForm(): void
     {
         $s = $this->q()->caseExpr('status')
             ->when('New', 't2.expose_new')
@@ -1668,7 +1668,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @doesNotPerformAssertions
      */
-    public function testCaseExprException1()
+    public function testCaseExprException1(): void
     {
         //$this->expectException(Exception::class);
         $this->q()->caseExpr()
@@ -1679,7 +1679,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * When using short form CASE statement, then you should not set array as when() method 1st parameter.
      */
-    public function testCaseExprException2()
+    public function testCaseExprException2(): void
     {
         $this->expectException(Exception::class);
         $this->q()->caseExpr('status')
@@ -1692,7 +1692,7 @@ class QueryTest extends AtkPhpunit\TestCase
      *
      * @covers ::exprNow
      */
-    public function testExprNow()
+    public function testExprNow(): void
     {
         $this->assertSame(
             'update "employee" set "hired"=current_timestamp()',
@@ -1714,7 +1714,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * Test table name with dots in it - Select.
      */
-    public function testTableNameDot1()
+    public function testTableNameDot1(): void
     {
         // render table
         $this->assertSame(
@@ -1746,7 +1746,7 @@ class QueryTest extends AtkPhpunit\TestCase
     /**
      * Test WITH.
      */
-    public function testWith()
+    public function testWith(): void
     {
         $q1 = $this->q()->table('salaries')->field('salary');
 
@@ -1797,7 +1797,7 @@ class QueryTest extends AtkPhpunit\TestCase
         );
     }
 
-    public function testExists()
+    public function testExists(): void
     {
         $this->assertSame(
             'select exists (select * from "contacts" where "first_name" = :a)',

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -19,7 +19,10 @@ use Atk4\Dsql\Sqlite;
  */
 class QueryTest extends AtkPhpunit\TestCase
 {
-    public function q(...$args)
+    /**
+     * @param string|array ...$args
+     */
+    public function q(...$args): Query
     {
         return new Query(...$args);
     }
@@ -44,7 +47,7 @@ class QueryTest extends AtkPhpunit\TestCase
     public function testDsql(): void
     {
         $q = $this->q(['connection' => new \stdClass()]);
-        $this->assertTrue($q->dsql()->connection instanceof \stdClass);
+        $this->assertInstanceOf(\stdClass::class, $q->dsql()->connection);
     }
 
     /**
@@ -535,7 +538,7 @@ class QueryTest extends AtkPhpunit\TestCase
         $q2 = $this->q()->table('customer');
 
         $this->assertSame(
-            // TODO this way it would be more correct:
+            // this way it would be more correct:
             // 'select "e"."name", "c"."name" from (select * from "employee") "e", (select * from "customer") "c" where "e"."last_name" = "c"."last_name"',
             'select "e"."name", "c"."name" from (select * from "employee") "e", (select * from "customer") "c" where "e"."last_name" = c.last_name',
             $this->q()
@@ -1461,7 +1464,7 @@ class QueryTest extends AtkPhpunit\TestCase
      */
     public function testSetException2(): void
     {
-        $this->q()->set((new Expression('foo')), 1);
+        $this->q()->set(new Expression('foo'), 1);
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -46,8 +46,8 @@ class QueryTest extends AtkPhpunit\TestCase
      */
     public function testDsql(): void
     {
-        $q = $this->q(['connection' => new \stdClass()]);
-        $this->assertInstanceOf(\stdClass::class, $q->dsql()->connection);
+        $q = $this->q(['connection' => new Mysql\Connection()]);
+        $this->assertInstanceOf(Mysql\Connection::class, $q->dsql()->connection);
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -16,7 +16,10 @@ use Atk4\Dsql\Sqlite;
  */
 class RandomTest extends AtkPhpunit\TestCase
 {
-    public function q(...$args)
+    /**
+     * @param string|array ...$args
+     */
+    public function q(...$args): Query
     {
         return new Query(...$args);
     }
@@ -69,7 +72,7 @@ class RandomTest extends AtkPhpunit\TestCase
     /**
      * Confirms that group concat works for all the SQL vendors we support.
      */
-    public function _groupConcatTest($expected, $q)
+    public function _groupConcatTest(string $expected, Query $q): void
     {
         $q->table('people');
         $q->group('age');

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -21,7 +21,7 @@ class RandomTest extends AtkPhpunit\TestCase
         return new Query(...$args);
     }
 
-    public function testMiscInsert()
+    public function testMiscInsert(): void
     {
         $data = [
             'id' => null,
@@ -79,7 +79,7 @@ class RandomTest extends AtkPhpunit\TestCase
         $this->assertSame($query, $q->render());
     }
 
-    public function testGroupConcat()
+    public function testGroupConcat(): void
     {
         $this->_groupConcatTest(
             new Mysql\Query(),

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -60,13 +60,16 @@ class RandomTest extends AtkPhpunit\TestCase
         foreach ($data as $key => $val) {
             $q->set($key, $val);
         }
-        $this->assertSame('insert into  ("id","system_id","system","created_dts","contractor_from","contractor_to","vat_rate_id","currency_id","vat_period_id","journal_spec_id","job_id","nominal_id","root_nominal_code","doc_type","is_cn","doc_date","ref_no","po_ref","total_gross","total_net","total_vat","exchange_rate","note","archive","fx_document_id","exchanged_total_net","exchanged_total_gross","exchanged_total_vat","exchanged_total_a","exchanged_total_b") values (:a,:b,:c,:d,:e,:f,:g,:h,:i,:j,:k,:l,:m,:n,:o,:p,:q,:r,:s,:t,:u,:v,:w,:x,:y,:z,:aa,:ab,:ac,:ad)', $q->render());
+        $this->assertSame(
+            'insert into  ("' . implode('", "', array_keys($data)) . '") values (:a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k, :l, :m, :n, :o, :p, :q, :r, :s, :t, :u, :v, :w, :x, :y, :z, :aa, :ab, :ac, :ad)',
+            $q->render()
+        );
     }
 
     /**
-     * confirms that group concat works for all the SQL vendors we support.
+     * Confirms that group concat works for all the SQL vendors we support.
      */
-    public function _groupConcatTest($q, $query)
+    public function _groupConcatTest($expected, $q)
     {
         $q->table('people');
         $q->group('age');
@@ -76,29 +79,29 @@ class RandomTest extends AtkPhpunit\TestCase
 
         $q->groupConcat('name', ',');
 
-        $this->assertSame($query, $q->render());
+        $this->assertSame($expected, $q->render());
     }
 
     public function testGroupConcat(): void
     {
         $this->_groupConcatTest(
-            new Mysql\Query(),
-            'select `age`,group_concat(`name` separator :a) from `people` group by `age`'
+            'select `age`, group_concat(`name` separator :a) from `people` group by `age`',
+            new Mysql\Query()
         );
 
         $this->_groupConcatTest(
-            new Sqlite\Query(),
-            'select "age",group_concat("name", :a) from "people" group by "age"'
+            'select "age", group_concat("name", :a) from "people" group by "age"',
+            new Sqlite\Query()
         );
 
         $this->_groupConcatTest(
-            new Postgresql\Query(),
-            'select "age",string_agg("name", :a) from "people" group by "age"'
+            'select "age", string_agg("name", :a) from "people" group by "age"',
+            new Postgresql\Query()
         );
 
         $this->_groupConcatTest(
-            new Oracle\Query(),
-            'select "age",listagg("name", :a) within group (order by "name") from "people" group by "age"'
+            'select "age", listagg("name", :a) within group (order by "name") from "people" group by "age"',
+            new Oracle\Query()
         );
     }
 }

--- a/tests/WithDb/ConnectionTest.php
+++ b/tests/WithDb/ConnectionTest.php
@@ -16,10 +16,10 @@ class ConnectionTest extends AtkPhpunit\TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testServerConnection()
+    public function testServerConnection(): void
     {
         $c = Connection::connect($GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD']);
 
-        return (string) $c->expr('SELECT 1' . ($c->getDatabasePlatform() instanceof OraclePlatform ? ' FROM DUAL' : ''))->getOne();
+        $this->assertSame('1', $c->expr('SELECT 1' . ($c->getDatabasePlatform() instanceof OraclePlatform ? ' FROM DUAL' : ''))->getOne());
     }
 }

--- a/tests/WithDb/ConnectionTest.php
+++ b/tests/WithDb/ConnectionTest.php
@@ -13,9 +13,6 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
  */
 class ConnectionTest extends AtkPhpunit\TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testServerConnection(): void
     {
         $c = Connection::connect($GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD']);

--- a/tests/WithDb/SelectTest.php
+++ b/tests/WithDb/SelectTest.php
@@ -8,6 +8,7 @@ use Atk4\Core\AtkPhpunit;
 use Atk4\Dsql\Connection;
 use Atk4\Dsql\Exception;
 use Atk4\Dsql\Expression;
+use Atk4\Dsql\Query;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
@@ -85,7 +86,11 @@ class SelectTest extends AtkPhpunit\TestCase
         $this->c = null; // @phpstan-ignore-line
     }
 
-    private function q($table = null, $alias = null)
+    /**
+     * @param mixed  $table
+     * @param string $alias
+     */
+    private function q($table = null, string $alias = null): Query
     {
         $q = $this->c->dsql();
 
@@ -97,7 +102,11 @@ class SelectTest extends AtkPhpunit\TestCase
         return $q;
     }
 
-    private function e($template = null, $args = null)
+    /**
+     * @param string|array $template
+     * @param array        $args
+     */
+    private function e($template = [], array $args = null): Expression
     {
         return $this->c->expr($template, $args);
     }

--- a/tests/WithDb/SelectTest.php
+++ b/tests/WithDb/SelectTest.php
@@ -102,7 +102,7 @@ class SelectTest extends AtkPhpunit\TestCase
         return $this->c->expr($template, $args);
     }
 
-    public function testBasicQueries()
+    public function testBasicQueries(): void
     {
         $this->assertSame(4, count($this->q('employee')->getRows()));
 
@@ -164,7 +164,7 @@ class SelectTest extends AtkPhpunit\TestCase
         );
     }
 
-    public function testExpression()
+    public function testExpression(): void
     {
         /*
          * PostgreSQL, at least versions before 10, needs to have the string cast to the
@@ -190,7 +190,7 @@ class SelectTest extends AtkPhpunit\TestCase
         }
     }
 
-    public function testOtherQueries()
+    public function testOtherQueries(): void
     {
         // truncate table
         $this->q('employee')->truncate();
@@ -259,7 +259,7 @@ class SelectTest extends AtkPhpunit\TestCase
         );
     }
 
-    public function testEmptyGetOne()
+    public function testEmptyGetOne(): void
     {
         // truncate table
         $this->q('employee')->truncate();
@@ -267,7 +267,7 @@ class SelectTest extends AtkPhpunit\TestCase
         $this->q('employee')->field('name')->getOne();
     }
 
-    public function testWhereExpression()
+    public function testWhereExpression(): void
     {
         $this->assertSame(
             [['id' => '2', 'name' => 'Jack', 'surname' => 'Williams', 'retired' => '1']],
@@ -275,7 +275,7 @@ class SelectTest extends AtkPhpunit\TestCase
         );
     }
 
-    public function testExecuteException()
+    public function testExecuteException(): void
     {
         $this->expectException(\Atk4\Dsql\ExecuteException::class);
 

--- a/tests/WithDb/TransactionTest.php
+++ b/tests/WithDb/TransactionTest.php
@@ -102,14 +102,14 @@ class TransactionTest extends AtkPhpunit\TestCase
         return $this->c->expr($template, $args);
     }
 
-    public function testCommitException1()
+    public function testCommitException1(): void
     {
         // try to commit when not in transaction
         $this->expectException(Exception::class);
         $this->c->commit();
     }
 
-    public function testCommitException2()
+    public function testCommitException2(): void
     {
         // try to commit when not in transaction anymore
         $this->c->beginTransaction();
@@ -118,14 +118,14 @@ class TransactionTest extends AtkPhpunit\TestCase
         $this->c->commit();
     }
 
-    public function testRollbackException1()
+    public function testRollbackException1(): void
     {
         // try to rollback when not in transaction
         $this->expectException(Exception::class);
         $this->c->rollBack();
     }
 
-    public function testRollbackException2()
+    public function testRollbackException2(): void
     {
         // try to rollback when not in transaction anymore
         $this->c->beginTransaction();
@@ -137,7 +137,7 @@ class TransactionTest extends AtkPhpunit\TestCase
     /**
      * Tests simple and nested transactions.
      */
-    public function testTransactions()
+    public function testTransactions(): void
     {
         // truncate table, prepare
         $this->q('employee')->truncate();
@@ -302,7 +302,7 @@ class TransactionTest extends AtkPhpunit\TestCase
     /**
      * Tests inTransaction().
      */
-    public function testInTransaction()
+    public function testInTransaction(): void
     {
         // inTransaction tests
         $this->assertFalse(

--- a/tests/WithDb/TransactionTest.php
+++ b/tests/WithDb/TransactionTest.php
@@ -8,6 +8,7 @@ use Atk4\Core\AtkPhpunit;
 use Atk4\Dsql\Connection;
 use Atk4\Dsql\Exception;
 use Atk4\Dsql\Expression;
+use Atk4\Dsql\Query;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
@@ -85,7 +86,11 @@ class TransactionTest extends AtkPhpunit\TestCase
         $this->c = null; // @phpstan-ignore-line
     }
 
-    private function q($table = null, $alias = null)
+    /**
+     * @param mixed  $table
+     * @param string $alias
+     */
+    private function q($table = null, string $alias = null): Query
     {
         $q = $this->c->dsql();
 
@@ -97,7 +102,11 @@ class TransactionTest extends AtkPhpunit\TestCase
         return $q;
     }
 
-    private function e($template = null, $args = null)
+    /**
+     * @param string|array $template
+     * @param array        $args
+     */
+    private function e($template = [], array $args = null): Expression
     {
         return $this->c->expr($template, $args);
     }


### PR DESCRIPTION
## BC break

arrays elements imploded by `,` are now joined with `, ` (comma + one space)

no action needed if rendered string is not used for comparison in tests